### PR TITLE
Improve desktop responsiveness

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -74,7 +74,7 @@ const App: React.FC = () => {
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header />
       <div className="flex flex-1 overflow-hidden">
-        <aside className="w-96 bg-gray-800 p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
+        <aside className="w-80 lg:w-96 hd:w-[28rem] 4k:w-[32rem] bg-gray-800 p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload
             onLayerAdded={handleLayerAdded}
             onLoading={handleLoading}

--- a/index.css
+++ b/index.css
@@ -2,3 +2,13 @@ html, body, #root {
   height: 100%;
   margin: 0;
 }
+
+html {
+  font-size: 16px;
+}
+
+@media (min-width: 3840px) {
+  html {
+    font-size: 18px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Shapefile Viewer Pro</title>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            screens: {
+              hd: '1920px',
+              '4k': '3840px',
+            }
+          }
+        }
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="


### PR DESCRIPTION
## Summary
- configure Tailwind to recognise `hd` and `4k` breakpoints
- widen sidebar for large screens
- adjust base font size for 4k displays

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867ff0c452483209b4518335bccbb94