### PR TITLE
Improve desktop scaling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -74,7 +74,7 @@ const App: React.FC = () => {
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header />
       <div className="flex flex-1 overflow-hidden">
-        <aside className="w-96 bg-gray-800 p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
+        <aside className="w-72 md:w-80 lg:w-96 2xl:w-[28rem] sidebar-4k bg-gray-800 p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload
             onLayerAdded={handleLayerAdded}
             onLoading={handleLoading}

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -139,7 +139,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
 
   return (
     <div className="bg-gray-700/50 p-6 rounded-lg border border-dashed border-gray-600">
-      <h2 className="text-lg font-semibold text-white mb-4">Upload Layer</h2>
+      <h2 className="text-lg lg:text-xl 2xl:text-2xl font-semibold text-white mb-4">Upload Layer</h2>
       <label
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
@@ -156,19 +156,19 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
-              <p className="mt-4 text-sm text-gray-400">Processing file...</p>
+              <p className="mt-4 text-sm lg:text-base 2xl:text-lg text-gray-400">Processing file...</p>
             </>
           ) : (
             <>
               <UploadIcon className="w-10 h-10 mb-3 text-gray-400" />
-              <p className="mb-2 text-sm text-gray-300"><span className="font-semibold text-cyan-400">Click to upload</span> or drag and drop</p>
-              <p className="text-xs text-gray-500">ZIP archive only (.zip)</p>
+              <p className="mb-2 text-sm lg:text-base 2xl:text-lg text-gray-300"><span className="font-semibold text-cyan-400">Click to upload</span> or drag and drop</p>
+              <p className="text-xs lg:text-sm 2xl:text-base text-gray-500">ZIP archive only (.zip)</p>
             </>
           )}
         </div>
         <input id="dropzone-file" type="file" className="hidden" onChange={handleFileChange} accept=".zip" disabled={isLoading} />
       </label>
-      <p className="mt-4 text-xs text-gray-500">
+      <p className="mt-4 text-xs lg:text-sm 2xl:text-base text-gray-500">
         Upload one or more shapefiles. WSS Soil Survey zips are handled automatically.
       </p>
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,8 +7,8 @@ const Header: React.FC = () => {
     <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
       <div>
-        <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
-        <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
+        <h1 className="text-xl lg:text-2xl 2xl:text-3xl font-bold text-white">Shapefile Viewer Pro</h1>
+        <p className="text-sm lg:text-base 2xl:text-lg text-gray-400">Upload and visualize your geographic data</p>
       </div>
     </header>
   );

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -24,7 +24,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
 
   return (
     <div className="bg-gray-700/50 p-6 rounded-lg border border-gray-600 flex-grow flex flex-col space-y-4">
-      <h2 className="text-lg font-semibold text-white">Layer Information</h2>
+      <h2 className="text-lg lg:text-xl 2xl:text-2xl font-semibold text-white">Layer Information</h2>
       <div className="space-y-4 flex-grow overflow-y-auto pr-2">
         {error && (
           <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg relative" role="alert">

--- a/components/LogPanel.tsx
+++ b/components/LogPanel.tsx
@@ -9,7 +9,7 @@ interface LogPanelProps {
 const LogPanel: React.FC<LogPanelProps> = ({ logs }) => {
   return (
     <div className="bg-gray-700/50 p-4 rounded-lg border border-gray-600 overflow-y-auto h-48 space-y-2">
-      <h2 className="text-lg font-semibold text-white mb-2">Log</h2>
+      <h2 className="text-lg lg:text-xl 2xl:text-2xl font-semibold text-white mb-2">Log</h2>
       {logs.length === 0 ? (
         <p className="text-gray-400 text-sm">No log messages yet.</p>
       ) : (

--- a/index.css
+++ b/index.css
@@ -2,3 +2,21 @@ html, body, #root {
   height: 100%;
   margin: 0;
 }
+
+/* Desktop scaling for 1080p and 4K */
+@media (min-width: 1920px) {
+  :root {
+    font-size: 18px;
+  }
+}
+@media (min-width: 3840px) {
+  :root {
+    font-size: 20px;
+  }
+}
+
+@media (min-width: 3840px) {
+  .sidebar-4k {
+    width: 36rem;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak header and panel text sizes for large screens
- improve sidebar width responsiveness
- adjust upload panel fonts
- add CSS rules for 1080p and 4K desktop scaling

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867ff0c452483209b4518335bccbb94