### PR TITLE
Add instructions placeholder before map loads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import Header from './components/Header';
 import FileUpload from './components/FileUpload';
 import InfoPanel from './components/InfoPanel';
 import MapComponent from './components/MapComponent';
+import InstructionsPage from './components/InstructionsPage';
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -90,7 +91,11 @@ const App: React.FC = () => {
           />
         </aside>
         <main className="flex-1 bg-gray-900 h-full">
-          <MapComponent layers={layers} />
+          {layers.length > 0 ? (
+            <MapComponent layers={layers} />
+          ) : (
+            <InstructionsPage />
+          )}
         </main>
       </div>
     </div>

--- a/components/InstructionsPage.tsx
+++ b/components/InstructionsPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const InstructionsPage: React.FC = () => {
+  return (
+    <div className="h-full w-full flex items-center justify-center bg-gray-900 text-gray-300 p-8">
+      <div className="max-w-prose text-center space-y-4">
+        <h2 className="text-2xl font-bold text-cyan-400">Welcome</h2>
+        <p>Upload a shapefile using the panel on the left to start the map.</p>
+        <p className="text-gray-500">// TODO: Add detailed instructions here</p>
+      </div>
+    </div>
+  );
+};
+
+export default InstructionsPage;


### PR DESCRIPTION
## Summary
- add new `InstructionsPage` component that displays placeholder text
- show `InstructionsPage` until a shapefile has been uploaded

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868046ddf84832096374d1f24f707a5