### PR TITLE
Add Google Maps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. Optionally set `GOOGLE_MAPS_API_KEY` in `.env.local` to enable Google Maps
+4. Run the app:
    `npm run dev`
-4. Start the backend server in another terminal:
+5. Start the backend server in another terminal:
    `npm run backend`
 
 ## Update soil HSG mapping

--- a/components/GoogleLayer.tsx
+++ b/components/GoogleLayer.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { createLayerComponent } from '@react-leaflet/core';
+import L from 'leaflet';
+import 'leaflet.gridlayer.googlemutant';
+
+export interface GoogleLayerProps {
+  type?: 'roadmap' | 'satellite' | 'terrain' | 'hybrid';
+}
+
+const createGoogleLayer = (props: GoogleLayerProps, context: any) => {
+  // @ts-ignore
+  const instance = (L.gridLayer as any).googleMutant({
+    type: props.type || 'roadmap',
+  });
+  return { instance, context };
+};
+
+const GoogleLayer = createLayerComponent<
+  L.GridLayer,
+  GoogleLayerProps
+>(createGoogleLayer);
+
+export const useLoadGoogleMaps = () => {
+  useEffect(() => {
+    if ((window as any).google && (window as any).google.maps) return;
+    const key = (process.env as any).GOOGLE_MAPS_API_KEY;
+    if (!key) return;
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${key}`;
+    script.async = true;
+    document.head.appendChild(script);
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+};
+
+export default GoogleLayer;

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
+import GoogleLayer, { useLoadGoogleMaps } from './GoogleLayer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
 
@@ -60,6 +61,7 @@ const ManagedGeoJsonLayer = ({
 };
 
 const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
+  useLoadGoogleMaps();
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full">
       <LayersControl position="topright">
@@ -82,18 +84,24 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
                 attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
             />
         </LayersControl.BaseLayer>
-         <LayersControl.BaseLayer name="Hybrid">
+        <LayersControl.BaseLayer name="Hybrid">
             <LayerGroup>
                 <TileLayer
                     url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
                     attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
                 />
-                 <TileLayer
+                <TileLayer
                     url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png"
                     attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-                    pane="shadowPane" 
+                    pane="shadowPane"
                 />
             </LayerGroup>
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Google Roadmap">
+          <GoogleLayer type="roadmap" />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Google Hybrid">
+          <GoogleLayer type="hybrid" />
         </LayersControl.BaseLayer>
 
         {/* Overlay Layers */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet.gridlayer.googlemutant": "^0.15.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
@@ -1303,6 +1304,12 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.gridlayer.googlemutant": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz",
+      "integrity": "sha512-kA5jCOBhCPigyue6YpZMhXMVYA1hM2pDIaJ6u0wSSiSZ2TQ4kZfKuhwkIexcadJfs0BP4FyhZIDZC7hmTlvjOA==",
+      "license": "Beerware"
     },
     "node_modules/lie": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "backend": "node server.js"
   },
   "dependencies": {
+    "express": "^4.19.2",
+    "geojson": "^0.5.0",
+    "jszip": "^3.10.1",
+    "leaflet": "^1.9.4",
+    "leaflet.gridlayer.googlemutant": "^0.15.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "geojson": "^0.5.0",
-    "shpjs": "^6.1.0",
-    "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
-    "jszip": "^3.10.1",
-    "express": "^4.19.2"
+    "shpjs": "^6.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.GOOGLE_MAPS_API_KEY': JSON.stringify(env.GOOGLE_MAPS_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- install leaflet.gridlayer.googlemutant
- add Google Maps layer component
- include Google layers in map
- support VITE_GOOGLE_MAPS_API_KEY
- document new env var

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68680bde66a083209c1c3fd34ca43381