### PR TITLE
Add Google Maps base layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. Optionally set `GOOGLE_MAPS_API_KEY` in the same file if you want to enable Google Maps tiles
+4. Run the app:
    `npm run dev`
-4. Start the backend server in another terminal:
+5. Start the backend server in another terminal:
    `npm run backend`
 
 ## Update soil HSG mapping

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -60,6 +60,7 @@ const ManagedGeoJsonLayer = ({
 };
 
 const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
+  const googleApiKey = process.env.GOOGLE_MAPS_API_KEY;
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full">
       <LayersControl position="topright">
@@ -82,19 +83,27 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
                 attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
             />
         </LayersControl.BaseLayer>
-         <LayersControl.BaseLayer name="Hybrid">
+        <LayersControl.BaseLayer name="Hybrid">
             <LayerGroup>
                 <TileLayer
                     url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
                     attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
                 />
-                 <TileLayer
+                <TileLayer
                     url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png"
                     attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-                    pane="shadowPane" 
+                    pane="shadowPane"
                 />
             </LayerGroup>
         </LayersControl.BaseLayer>
+        {googleApiKey && (
+          <LayersControl.BaseLayer name="Google Maps">
+            <TileLayer
+              url={`https://mts1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}&key=${googleApiKey}`}
+              attribution="Map data &copy; Google"
+            />
+          </LayersControl.BaseLayer>
+        )}
 
         {/* Overlay Layers */}
         {layers.map((layer, index) => (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.GOOGLE_MAPS_API_KEY': JSON.stringify(env.GOOGLE_MAPS_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- optionally load Google Maps tiles when `GOOGLE_MAPS_API_KEY` is provided
- expose `GOOGLE_MAPS_API_KEY` in Vite config
- document Google Maps key setup

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68680bde66a083209c1c3fd34ca43381