### PR TITLE
Add Google Maps layers

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your-gemini-key
+GOOGLE_MAPS_API_KEY=your-google-maps-key

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create an `.env.local` file with your API keys:
+   ```
+   GEMINI_API_KEY=your-gemini-key
+   GOOGLE_MAPS_API_KEY=your-google-maps-key
+   ```
+   Replace `your-google-maps-key` with `AIzaSyBsEK-S5Kbf5aqYol5eGv8uYcPgLOlObr4` if you wish to use the provided key.
+   Note: Google Maps tiles will display a "for development purposes only" watermark if the API key is not fully configured.
+   To remove the watermark, ensure billing is enabled for your Google Cloud project and that the key is authorized for your domain.
 3. Run the app:
    `npm run dev`
 4. Start the backend server in another terminal:

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
+import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
+
+const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
 interface MapComponentProps {
   layers: LayerData[];
@@ -82,7 +85,19 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
                 attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
             />
         </LayersControl.BaseLayer>
-         <LayersControl.BaseLayer name="Hybrid">
+        <LayersControl.BaseLayer name="Google Roadmap">
+          <ReactLeafletGoogleLayer apiKey={googleMapsApiKey} type="roadmap" />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Google Satellite">
+          <ReactLeafletGoogleLayer apiKey={googleMapsApiKey} type="satellite" />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Google Terrain">
+          <ReactLeafletGoogleLayer apiKey={googleMapsApiKey} type="terrain" />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Google Hybrid">
+          <ReactLeafletGoogleLayer apiKey={googleMapsApiKey} type="hybrid" />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="Hybrid">
             <LayerGroup>
                 <TileLayer
                     url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
+        "react-leaflet-google-layer": "^4.0.0",
         "shpjs": "^6.1.0"
       },
       "devDependencies": {
@@ -448,6 +449,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz",
+      "integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
@@ -745,6 +752,30 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.19",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.19.tgz",
+      "integrity": "sha512-pB+n2daHcZPF2FDaWa+6B0a0mSDf4dPU35y5iTXsx7x/PzzshiX5atYiS1jlBn43X7XvM8AP+AB26lnSk0J4GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet.gridlayer.googlemutant": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.4.9.tgz",
+      "integrity": "sha512-u/5Avs1KKkeABRDixGbGp2ldFs67+fYIATpkvvFgN+LQPNfq7dFd5adkksshiQBfYJ4SaQg1VJgN2dNirIC0aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.16.0",
@@ -1304,6 +1335,12 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.gridlayer.googlemutant": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz",
+      "integrity": "sha512-kA5jCOBhCPigyue6YpZMhXMVYA1hM2pDIaJ6u0wSSiSZ2TQ4kZfKuhwkIexcadJfs0BP4FyhZIDZC7hmTlvjOA==",
+      "license": "Beerware"
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -1626,6 +1663,24 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-google-layer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-google-layer/-/react-leaflet-google-layer-4.0.0.tgz",
+      "integrity": "sha512-qZNH9ZzvZRk+9OAMbkrazjpqAtfrdCA1zk11n0ls/dKyD84zhqTaPzrDVHnqzCk5Khdg0ZhGMcSjWpn0KhBnDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^1.8.0",
+        "@types/leaflet": "^1.5.0",
+        "@types/leaflet.gridlayer.googlemutant": "^0.4.9",
+        "leaflet.gridlayer.googlemutant": "^0.15.0"
+      },
+      "peerDependencies": {
+        "leaflet": ">=1.5.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-leaflet": ">=3.0.0"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "shpjs": "^6.1.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
+    "react-leaflet-google-layer": "^4.0.0",
     "jszip": "^3.10.1",
     "express": "^4.19.2"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.GOOGLE_MAPS_API_KEY': JSON.stringify(env.GOOGLE_MAPS_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- add `react-leaflet-google-layer` dependency
- support Google Maps layers in `MapComponent`
- expose `GOOGLE_MAPS_API_KEY` in Vite config
- document API key usage and example env vars
- clarify that Google Maps needs a fully-configured key

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68680bde66a083209c1c3fd34ca43381