### PR TITLE
Add map search box using Google geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This contains everything you need to run your app locally.
    Replace `your-google-maps-key` with `AIzaSyBsEK-S5Kbf5aqYol5eGv8uYcPgLOlObr4` if you wish to use the provided key.
    Note: Google Maps tiles will display a "for development purposes only" watermark if the API key is not fully configured.
    To remove the watermark, ensure billing is enabled for your Google Cloud project and that the key is authorized for your domain.
+   The same key is also used for the map search box.
 3. Run the app:
    `npm run dev`
 4. Start the backend server in another terminal:

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -3,6 +3,7 @@ import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } f
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
+import SearchBox from './SearchBox';
 
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
@@ -64,8 +65,9 @@ const ManagedGeoJsonLayer = ({
 
 const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
   return (
-    <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full">
-      <LayersControl position="topright">
+    <div className="relative h-full w-full">
+      <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full">
+        <LayersControl position="topright">
         {/* Base Layers */}
         <LayersControl.BaseLayer checked name="Dark">
           <TileLayer
@@ -121,8 +123,12 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
              />
           </LayersControl.Overlay>
         ))}
-      </LayersControl>
-    </MapContainer>
+        </LayersControl>
+      </MapContainer>
+      <div className="absolute top-2 right-2 z-[1000]">
+        <SearchBox />
+      </div>
+    </div>
   );
 };
 

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useMap } from 'react-leaflet';
+
+const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
+
+const SearchBox: React.FC = () => {
+  const map = useMap();
+  const [query, setQuery] = useState('');
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+
+    const latLonMatch = q.match(/^(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)$/);
+    if (latLonMatch) {
+      const lat = parseFloat(latLonMatch[1]);
+      const lon = parseFloat(latLonMatch[2]);
+      map.flyTo([lat, lon], 14);
+      return;
+    }
+
+    if (!googleMapsApiKey) {
+      alert('Google Maps API key not configured');
+      return;
+    }
+
+    try {
+      const res = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(q)}&key=${googleMapsApiKey}`);
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      const first = data.results?.[0];
+      if (first) {
+        const { lat, lng } = first.geometry.location;
+        map.flyTo([lat, lng], 14);
+      } else {
+        alert('Location not found');
+      }
+    } catch (err) {
+      console.error('Geocoding error', err);
+      alert('Failed to search location');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSearch} className="flex bg-white rounded shadow-md overflow-hidden">
+      <input
+        type="text"
+        className="px-2 py-1 text-sm text-gray-800 outline-none flex-grow"
+        placeholder="Address or lat,lng"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button type="submit" className="px-3 bg-cyan-600 text-white text-sm">Go</button>
+    </form>
+  );
+};
+
+export default SearchBox;

--- a/index.css
+++ b/index.css
@@ -19,3 +19,8 @@ html, body, #root {
     font-size: 20px;
   }
 }
+
+/* Offset the layer control to leave room for the search box */
+.leaflet-control-layers {
+  margin-top: 3rem;
+}


### PR DESCRIPTION
## Summary
- implement a SearchBox component that queries Google Maps geocoding
- display the search box above the basemap selector in MapComponent
- offset basemap control to make room for search box
- update README with note about API key usage

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686816c42e7c8320bee3e50791e8f1d3