### PR TITLE
Add search box using Google Maps

### DIFF
--- a/index.css
+++ b/index.css
@@ -19,3 +19,8 @@ html, body, #root {
     font-size: 20px;
   }
 }
+
+/* Position Leaflet controls below the search box */
+.leaflet-top.leaflet-right {
+  top: 3.5rem;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shapefile-viewer-pro",
       "version": "0.0.0",
       "dependencies": {
+        "@googlemaps/js-api-loader": "^1.16.10",
         "express": "^4.19.2",
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "backend": "node server.js"
   },
   "dependencies": {
+    "@googlemaps/js-api-loader": "^1.16.10",
+    "express": "^4.19.2",
+    "geojson": "^0.5.0",
+    "jszip": "^3.10.1",
+    "leaflet": "^1.9.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "geojson": "^0.5.0",
-    "shpjs": "^6.1.0",
-    "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
     "react-leaflet-google-layer": "^4.0.0",
-    "jszip": "^3.10.1",
-    "express": "^4.19.2"
+    "shpjs": "^6.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- add Google Maps Loader and use Google Places Autocomplete in SearchBox
- fall back to provided Google API key
- reposition layer control so search box doesn't overlap

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686816c42e7c8320bee3e50791e8f1d3