### PR TITLE
Add Google Places search box

### DIFF
--- a/index.css
+++ b/index.css
@@ -19,3 +19,8 @@ html, body, #root {
     font-size: 20px;
   }
 }
+
+/* push layer control down so search box can sit above */
+.leaflet-control-layers {
+  margin-top: 3.5rem;
+}


### PR DESCRIPTION
## Summary
- add Google Maps API key fallback to MapComponent
- load Places library for search autocomplete
- geocode selected location
- adjust layer control margin so search box doesn't overlap

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686816c42e7c8320bee3e50791e8f1d3