### PR TITLE
Add address search feature

### DIFF
--- a/components/AddressSearch.tsx
+++ b/components/AddressSearch.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useMap } from 'react-leaflet';
+import { SearchIcon } from './Icons';
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+
+const AddressSearch: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const map = useMap();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    // Check for lat,long pattern
+    const coordMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)[ ,]+(-?\d+(?:\.\d+)?)/);
+    if (coordMatch) {
+      const lat = parseFloat(coordMatch[1]);
+      const lon = parseFloat(coordMatch[2]);
+      map.flyTo([lat, lon], 14);
+      return;
+    }
+
+    try {
+      const params = new URLSearchParams({
+        q: trimmed,
+        format: 'json',
+        addressdetails: '1',
+        limit: '1'
+      });
+      const res = await fetch(`${NOMINATIM_URL}?${params.toString()}`, {
+        headers: { 'Accept-Language': 'en', 'User-Agent': 'shapefile-viewer-pro' }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.length > 0) {
+          const { lat, lon } = data[0];
+          map.flyTo([parseFloat(lat), parseFloat(lon)], 14);
+        }
+      } else {
+        console.warn('Geocoding request failed', res.status);
+      }
+    } catch (err) {
+      console.error('Geocoding error', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex space-x-2">
+      <input
+        type="text"
+        className="w-full p-2 rounded bg-gray-800 border border-gray-600 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-cyan-400"
+        placeholder="Address or lat,lng"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="p-2 rounded bg-cyan-600 text-white hover:bg-cyan-500 focus:outline-none"
+        aria-label="Search"
+      >
+        <SearchIcon className="w-5 h-5" />
+      </button>
+    </form>
+  );
+};
+
+export default AddressSearch;

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -39,3 +39,9 @@ export const TrashIcon: React.FC<IconProps> = ({ className }) => (
         <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
     </svg>
 );
+
+export const SearchIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
+  </svg>
+);

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
+import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
@@ -64,7 +65,10 @@ const ManagedGeoJsonLayer = ({
 
 const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
   return (
-    <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full">
+    <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
+      <div className="absolute top-2 left-2 z-[1000] w-64">
+        <AddressSearch />
+      </div>
       <LayersControl position="topright">
         {/* Base Layers */}
         <LayersControl.BaseLayer checked name="Dark">


### PR DESCRIPTION
## Summary
- allow searching by address or lat/long coordinates
- create `AddressSearch` component
- add search icon
- embed address search box on the map

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68682038cfb883208efe15bea07c5fd6