### PR TITLE
Enable editing HSG interactively

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -71,6 +71,19 @@ const App: React.FC = () => {
     addLog(`Removed layer ${id}`);
   }, [addLog]);
 
+  const handleUpdateHsg = useCallback((layerId: string, featureIndex: number, newHsg: string) => {
+    setLayers(prevLayers => prevLayers.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const updated = { ...layer.geojson, features: [...layer.geojson.features] };
+      const feature = updated.features[featureIndex];
+      if (feature && feature.properties) {
+        (feature.properties as any).HSG = newHsg;
+      }
+      return { ...layer, geojson: updated };
+    }));
+    addLog(`Updated HSG for feature ${featureIndex} in ${layerId} to ${newHsg}`);
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header />
@@ -92,7 +105,7 @@ const App: React.FC = () => {
         </aside>
         <main className="flex-1 bg-gray-900 h-full">
           {layers.length > 0 ? (
-            <MapComponent layers={layers} />
+            <MapComponent layers={layers} onUpdateHsg={handleUpdateHsg} />
           ) : (
             <InstructionsPage />
           )}

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -88,6 +88,12 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       }
       // --- END OF ENRICHMENT LOGIC ---
 
+      // assign internal index to each feature for easier updates later
+      geojson.features.forEach((feature, idx) => {
+        if (!feature.properties) feature.properties = {} as any;
+        (feature.properties as any).__index = idx;
+      });
+
       onLayerAdded(geojson, displayName);
       onLog(`Loaded ${displayName}`);
     } catch (e) {


### PR DESCRIPTION
## Summary
- add index property to features on upload
- support updating polygon HSG values
- double-click a polygon on the map to change its HSG

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bf4aa257c8320bca54114ba21cecd