### PR TITLE
Add interactive HSG editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,8 @@ import InfoPanel from './components/InfoPanel';
 import MapComponent from './components/MapComponent';
 import InstructionsPage from './components/InstructionsPage';
 
+type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
+
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -71,6 +73,18 @@ const App: React.FC = () => {
     addLog(`Removed layer ${id}`);
   }, [addLog]);
 
+  const handleUpdateFeatureHsg = useCallback<UpdateHsgFn>((layerId, featureIndex, hsg) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), HSG: hsg };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set HSG for feature ${featureIndex} in ${layerId} to ${hsg}`);
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header />
@@ -92,7 +106,7 @@ const App: React.FC = () => {
         </aside>
         <main className="flex-1 bg-gray-900 h-full">
           {layers.length > 0 ? (
-            <MapComponent layers={layers} />
+            <MapComponent layers={layers} onUpdateFeatureHsg={handleUpdateFeatureHsg} />
           ) : (
             <InstructionsPage />
           )}

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
+import L from 'leaflet';
 import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
@@ -9,6 +10,7 @@ const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
 interface MapComponentProps {
   layers: LayerData[];
+  onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -17,20 +19,58 @@ const ManagedGeoJsonLayer = ({
   id,
   data,
   isLastAdded,
+  onUpdateFeatureHsg,
 }: {
   id: string;
   data: LayerData['geojson'];
   isLastAdded: boolean;
+  onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
 }) => {
   const geoJsonRef = useRef<LeafletGeoJSON | null>(null);
   const map = useMap();
 
   const onEachFeature = (feature: GeoJSON.Feature, layer: Layer) => {
     if (feature.properties) {
-      const popupContent = `<div style="max-height: 150px; overflow-y: auto; font-family: sans-serif;">${Object.entries(feature.properties)
-        .map(([key, value]) => `<b>${key}:</b> ${value}`)
-        .join('<br/>')}</div>`;
-      layer.bindPopup(popupContent);
+      const container = L.DomUtil.create('div');
+      container.style.maxHeight = '150px';
+      container.style.overflowY = 'auto';
+      container.style.fontFamily = 'sans-serif';
+
+      const propsDiv = L.DomUtil.create('div', '', container);
+
+      // Render all properties except HSG
+      Object.entries(feature.properties).forEach(([k, v]) => {
+        if (k === 'HSG') return;
+        const row = L.DomUtil.create('div', '', propsDiv);
+        row.innerHTML = `<b>${k}:</b> ${v}`;
+      });
+
+      // Special editable field for HSG
+      if ('HSG' in feature.properties) {
+        const hsgRow = L.DomUtil.create('div', '', propsDiv);
+        const label = L.DomUtil.create('b', '', hsgRow);
+        label.textContent = 'HSG: ';
+        const select = L.DomUtil.create('select', '', hsgRow) as HTMLSelectElement;
+        select.title = 'Cambiar HSG';
+        select.style.marginLeft = '4px';
+        select.style.border = '2px solid #f59e0b';
+        select.style.backgroundColor = '#fef3c7';
+        select.style.fontWeight = 'bold';
+        ['A', 'B', 'C', 'D'].forEach(val => {
+          const opt = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+          opt.value = val;
+          opt.textContent = val;
+          if (feature.properties!.HSG === val) opt.selected = true;
+        });
+        select.addEventListener('change', (e) => {
+          const newVal = (e.target as HTMLSelectElement).value;
+          const idx = data.features.indexOf(feature);
+          onUpdateFeatureHsg(id, idx, newVal);
+          feature.properties!.HSG = newVal;
+        });
+      }
+
+      layer.bindPopup(container);
     }
   };
 
@@ -63,7 +103,7 @@ const ManagedGeoJsonLayer = ({
   );
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
+const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg }) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <div className="absolute top-2 left-2 z-[1000] w-64">
@@ -122,6 +162,7 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers }) => {
                 id={layer.id}
                 data={layer.geojson}
                 isLastAdded={index === layers.length - 1}
+                onUpdateFeatureHsg={onUpdateFeatureHsg}
              />
           </LayersControl.Overlay>
         ))}


### PR DESCRIPTION
## Summary
- update map popup so HSG can be changed per feature
- keep the new HSG value in app state
- combine HSG display and editing in a single dropdown
- highlight the dropdown so it's obvious it's editable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bf4aa257c8320bca54114ba21cecd