### PR TITLE
Add HSG mapping verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ You can limit the update to specific area symbols:
 python scripts/update_soil_hsg_map.py --areas CA630 CA649
 ```
 
+## Verify soil HSG mapping
+
+After updating the dataset you can verify that the letters match the
+current values from the Soil Data Access API using the
+`verify_soil_hsg_map.py` script.  It will report any mismatched MUSYM
+codes and exits with a non-zero status when differences are found.
+
+```bash
+python scripts/verify_soil_hsg_map.py --areas CA630 CA649
+```
+
+To check all available data in one large query use the `--fast` flag:
+
+```bash
+python scripts/verify_soil_hsg_map.py --fast
+```
+
 ## Desktop layout
 
 The default styles target 1080p displays but scale gracefully up to 4K

--- a/scripts/verify_soil_hsg_map.py
+++ b/scripts/verify_soil_hsg_map.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify the MUSYM to HSG mapping against the USDA Soil Data Access API."""
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Dict
+
+from update_soil_hsg_map import (
+    get_area_symbols,
+    fetch_musym_hsg,
+    fetch_all_musym_hsg,
+    load_existing_map,
+)
+
+
+def verify_pairs(pairs: Dict[str, str], mapping: Dict[str, str]) -> int:
+    mismatches = []
+    for musym, hsg in pairs.items():
+        mapped = mapping.get(musym)
+        if mapped != hsg:
+            mismatches.append((musym, mapped, hsg))
+    if mismatches:
+        print("Found mismatched HSG values:")
+        for musym, mapped, hsg in mismatches[:20]:
+            print(f"  {musym}: file={mapped!r} api={hsg!r}")
+        print(f"Total mismatches: {len(mismatches)}")
+        return 1
+    print("No mismatches found.")
+    return 0
+
+
+def verify_areas(areas: Iterable[str]) -> int:
+    mapping = load_existing_map()
+    all_pairs: Dict[str, str] = {}
+    for area in areas:
+        print(f"Checking {area}...")
+        try:
+            pairs = fetch_musym_hsg(area)
+            all_pairs.update(pairs)
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to fetch {area}: {exc}")
+    return verify_pairs(all_pairs, mapping)
+
+
+def verify_all_fast() -> int:
+    mapping = load_existing_map()
+    print("Fetching all MUSYM/HSG pairs in bulk for verification...")
+    try:
+        pairs = fetch_all_musym_hsg()
+    except Exception as exc:  # noqa: BLE001
+        print(f"Bulk fetch failed: {exc}")
+        return 1
+    return verify_pairs(pairs, mapping)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify soil-hsg-map.json")
+    parser.add_argument(
+        "--areas",
+        nargs="*",
+        help="Area symbols to verify. Defaults to all areas.",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Fetch all MUSYM/HSG pairs in one query",
+    )
+    args = parser.parse_args(argv)
+
+    if args.fast:
+        return verify_all_fast()
+
+    if args.areas:
+        areas = args.areas
+    else:
+        areas = get_area_symbols()
+
+    return verify_areas(areas)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify_soil_hsg_map.py` utility to check MUSYM→HSG entries with USDA API
- document verification usage in README

## Testing
- `python scripts/verify_soil_hsg_map.py --areas CA630 >/tmp/out.txt`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe4d6fd2c832093cbf28350883a4c