### PR TITLE
Enable LOD polygon drawing and detection

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -62,6 +62,10 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       }
 
       let geojson = await shp.parseZip(buffer) as FeatureCollection;
+      const isLodFile = /lod|limit.*disturbance/i.test(displayName);
+      if (isLodFile) {
+        displayName = 'Limit of Disturbance (LOD)';
+      }
 
       // --- DATA ENRICHMENT FOR WSS FILES ---
       if (isWssFile && geojson.features.length > 0) {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {
@@ -26,7 +27,9 @@
     "shpjs": "https://esm.sh/shpjs@^6.1.0",
     "leaflet": "https://esm.sh/leaflet@^1.9.4",
     "react-leaflet": "https://esm.sh/react-leaflet@^5.0.0",
-    "jszip": "https://esm.sh/jszip@^3.10.1"
+    "jszip": "https://esm.sh/jszip@^3.10.1",
+    "leaflet-draw": "https://esm.sh/leaflet-draw@^1.0.4",
+    "react-leaflet-draw": "https://esm.sh/react-leaflet-draw@^0.20.6"
   }
 }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,17 @@
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
+        "react-leaflet-draw": "^0.20.6",
         "react-leaflet-google-layer": "^4.0.0",
         "shpjs": "^6.1.0"
       },
       "devDependencies": {
+        "@types/leaflet-draw": "^1.0.12",
         "@types/node": "^22.14.0",
         "typescript": "~5.7.2",
         "vite": "^6.2.0"
@@ -768,6 +772,16 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/leaflet-draw": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-draw/-/leaflet-draw-1.0.12.tgz",
+      "integrity": "sha512-ayjGxelc3pp7532852Qn/LYHs/CHOcUqM9iDVsXuIXbIGfM2h3OtsHO/sQzFO6GAz2IvslPupgJaYocsY8NH+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
     "node_modules/@types/leaflet.gridlayer.googlemutant": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/@types/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.4.9.tgz",
@@ -1105,6 +1119,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -1317,6 +1337,12 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -1335,6 +1361,12 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
+    },
     "node_modules/leaflet.gridlayer.googlemutant": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz",
@@ -1348,6 +1380,24 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1457,6 +1507,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1578,6 +1637,17 @@
         "url": "https://github.com/sponsors/ahocevar"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1651,6 +1721,12 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
@@ -1663,6 +1739,23 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-draw": {
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.20.6.tgz",
+      "integrity": "sha512-mGypDjJNrrnVpfKfGYovNBuJZXSk39ClOdUJe/5dB5Cj3f2BGQlY9txyV4UmUxZCbc96aq+FMwrGZeM4BokhHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.5.2",
+        "react": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-leaflet-google-layer": {

--- a/package.json
+++ b/package.json
@@ -10,17 +10,21 @@
     "backend": "node server.js"
   },
   "dependencies": {
+    "express": "^4.19.2",
+    "geojson": "^0.5.0",
+    "jszip": "^3.10.1",
+    "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "geojson": "^0.5.0",
-    "shpjs": "^6.1.0",
-    "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
+    "react-leaflet-draw": "^0.20.6",
     "react-leaflet-google-layer": "^4.0.0",
-    "jszip": "^3.10.1",
-    "express": "^4.19.2"
+    "shpjs": "^6.1.0"
   },
   "devDependencies": {
+    "@types/leaflet-draw": "^1.0.12",
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"


### PR DESCRIPTION
## Summary
- add leaflet-draw and react-leaflet-draw for editing tools
- wire up draw control in `MapComponent` and expose `onLodCreated`
- detect LOD shapefiles on upload and when drawing
- add `handleLodCreated` in `App` to manage the Limit of Disturbance layer
- include leaflet-draw styles and importmap entries

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fe54b215c8320ace1782107ffcdcc