### PR TITLE
Add LOD polygon layer with drawing support

### DIFF
--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
+import type { FeatureCollection } from 'geojson';
 import { XCircleIcon, InfoIcon, TrashIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
   layers: LayerData[];
+  lodLayer: FeatureCollection | null;
   error: string | null;
   logs: LogEntry[];
   onRemoveLayer: (id: string) => void;
+  onClearLod: () => void;
   onZoomToLayer?: (id: string) => void;
+  onZoomToLod?: () => void;
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer }) => {
+const InfoPanel: React.FC<InfoPanelProps> = ({ layers, lodLayer, error, logs, onRemoveLayer, onClearLod, onZoomToLayer, onZoomToLod }) => {
 
   const getFeatureTypeSummary = (geojson: LayerData['geojson']) => {
     if (!geojson) return {};
@@ -38,13 +42,31 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
             </div>
           </div>
         )}
-        {!error && layers.length === 0 && (
+        {!error && layers.length === 0 && !lodLayer && (
           <div className="bg-blue-900/50 border border-blue-700 text-blue-300 px-4 py-3 rounded-lg h-full flex items-center justify-center" role="status">
             <div className="flex items-center">
               <InfoIcon className="w-6 h-6 mr-3 text-blue-400"/>
               <p>Ready to visualize. Upload a layer.</p>
             </div>
           </div>
+        )}
+        {lodLayer && (
+           <div className="space-y-3">
+              <div
+                className="bg-gray-800 p-4 rounded-lg border border-gray-600/50 cursor-pointer hover:border-cyan-400"
+                onClick={() => onZoomToLod && onZoomToLod()}
+              >
+                <div className="flex justify-between items-start">
+                  <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">Limit of Disturbance (LOD)</h3>
+                  <button onClick={onClearLod} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label="Remove LOD">
+                    <TrashIcon className="w-5 h-5" />
+                  </button>
+                </div>
+                <div className="text-gray-300 space-y-2 text-sm">
+                   <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{lodLayer.features.length}</span></p>
+                </div>
+              </div>
+           </div>
         )}
         {layers.length > 0 && (
            <div className="space-y-3">

--- a/components/LodUpload.tsx
+++ b/components/LodUpload.tsx
@@ -1,0 +1,186 @@
+import React, { useCallback, useState } from 'react';
+import * as shp from 'shpjs';
+import JSZip from 'jszip';
+import type { FeatureCollection } from 'geojson';
+import { UploadIcon } from './Icons';
+
+interface LodUploadProps {
+  onLodAdded: (data: FeatureCollection) => void;
+  onLoading: () => void;
+  onError: (message: string) => void;
+  onLog: (message: string, type?: 'info' | 'error') => void;
+  isLoading: boolean;
+}
+
+const LodUpload: React.FC<LodUploadProps> = ({ onLodAdded, onLoading, onError, onLog, isLoading }) => {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const processFile = useCallback(async (file: File) => {
+    if (!file) {
+      onError("No file selected.");
+      onLog("No file selected", 'error');
+      return;
+    }
+    if (!file.name.toLowerCase().endsWith('.zip')) {
+      const msg = "Invalid file type. Please upload a .zip file containing your shapefile components (.shp, .dbf, .prj, etc.).";
+      onError(msg);
+      onLog(msg, 'error');
+      return;
+    }
+
+    onLoading();
+    onLog(`Processing ${file.name}...`);
+
+    try {
+      let buffer = await file.arrayBuffer();
+      let displayName = file.name;
+      const isWssFile = file.name.toLowerCase().startsWith('wss_aoi_');
+
+      // Special handling for Web Soil Survey files
+      if (isWssFile) {
+        const targetBasename = 'soilmu_a_aoi';
+        const zip = await JSZip.loadAsync(buffer);
+        
+        const relevantFiles = zip.file(new RegExp(`(^|/)${targetBasename}\\.\\w+$`, 'i'));
+
+        if (relevantFiles.length === 0) {
+          onError(`Could not find '${targetBasename}.shp' in the WSS archive.`);
+          return;
+        }
+
+        const newZip = new JSZip();
+        for (const zipObject of relevantFiles) {
+          const fileNameOnly = zipObject.name.split('/').pop();
+          if(fileNameOnly) {
+            newZip.file(fileNameOnly, await zipObject.async('arraybuffer'));
+          }
+        }
+        
+        buffer = await newZip.generateAsync({ type: 'arraybuffer' });
+        displayName = `${targetBasename}.shp`;
+      }
+
+      let geojson = await shp.parseZip(buffer) as FeatureCollection;
+
+      // --- DATA ENRICHMENT FOR WSS FILES ---
+      if (isWssFile && geojson.features.length > 0) {
+        try {
+          const hsgMap = await loadHsgMap();
+          if (hsgMap) {
+            geojson.features.forEach(feature => {
+              if (feature.properties && feature.properties.MUSYM) {
+                const musym = String(feature.properties.MUSYM);
+                const rawHsg = hsgMap[musym] || 'N/A';
+                const hsg = typeof rawHsg === 'string' ? rawHsg.split('/')[0] : rawHsg;
+                feature.properties.HSG = hsg;
+              }
+            });
+            onLog('Soil data enriched');
+          } else {
+            const msg = 'Could not load soil HSG data. Skipping enrichment.';
+            console.warn(msg);
+            onLog(msg, 'error');
+          }
+        } catch (enrichError) {
+          console.error('Failed to enrich soil data:', enrichError);
+          onLog('Failed to enrich soil data', 'error');
+        }
+      }
+      // --- END OF ENRICHMENT LOGIC ---
+
+      // Validate geometry type is polygonal
+      const allPolygons = geojson.features.every(f =>
+        f.geometry.type === 'Polygon' || f.geometry.type === 'MultiPolygon'
+      );
+      if (!allPolygons) {
+        const msg = 'LOD must contain only polygon features.';
+        onError(msg);
+        onLog(msg, 'error');
+        return;
+      }
+
+      onLodAdded(geojson);
+      onLog(`Loaded ${displayName}`);
+    } catch (e) {
+      console.error("File parsing error:", e);
+      const errMsg = "Failed to parse shapefile. Ensure the .zip contains valid .shp and .dbf files, and for WSS zips, that 'soilmu_a_aoi.shp' is present.";
+      onError(errMsg);
+      onLog(errMsg, 'error');
+    }
+  }, [onLodAdded, onLoading, onError, onLog]);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      processFile(file);
+    }
+    event.target.value = ''; // Reset input to allow re-uploading the same file
+  };
+
+  const handleDragEnter = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+  
+  const handleDragLeave = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault(); // Necessary to allow drop
+    e.stopPropagation();
+  };
+  
+  const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+    
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      processFile(file);
+    }
+  };
+
+  return (
+    <div className="bg-gray-700/50 p-6 rounded-lg border border-dashed border-gray-600">
+      <h2 className="text-lg font-semibold text-white mb-4">Upload Limit of Disturbance (LOD)</h2>
+      <label
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className={`flex flex-col items-center justify-center w-full h-48 border-2 border-dashed rounded-lg cursor-pointer transition-colors
+          ${isDragging ? 'border-cyan-400 bg-gray-700' : 'border-gray-500 hover:border-gray-400 bg-gray-800'}
+        `}
+      >
+        <div className="flex flex-col items-center justify-center pt-5 pb-6 text-center">
+          {isLoading ? (
+            <>
+              <svg className="animate-spin -ml-1 mr-3 h-10 w-10 text-cyan-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <p className="mt-4 text-sm text-gray-400">Processing file...</p>
+            </>
+          ) : (
+            <>
+              <UploadIcon className="w-10 h-10 mb-3 text-gray-400" />
+              <p className="mb-2 text-sm text-gray-300"><span className="font-semibold text-cyan-400">Click to upload</span> or drag and drop</p>
+              <p className="text-xs text-gray-500">ZIP archive only (.zip)</p>
+            </>
+          )}
+        </div>
+        <input id="dropzone-file" type="file" className="hidden" onChange={handleFileChange} accept=".zip" disabled={isLoading} />
+      </label>
+      <p className="mt-4 text-xs text-gray-500">
+        Upload a polygon shapefile defining the Limit of Disturbance.
+      </p>
+    </div>
+  );
+};
+
+export default LodUpload;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css"
+      integrity="sha256-XzD3RpaHPv7lzX9qt+2n1j5cWj48O24KsgaGYpKN8x8="
+      crossorigin=""/>
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
+        "react-leaflet-draw": "^0.20.6",
         "react-leaflet-google-layer": "^4.0.0",
         "shpjs": "^6.1.0"
       },
@@ -1105,6 +1108,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -1317,6 +1326,12 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -1335,6 +1350,12 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
+    },
     "node_modules/leaflet.gridlayer.googlemutant": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz",
@@ -1348,6 +1369,24 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1457,6 +1496,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1578,6 +1626,17 @@
         "url": "https://github.com/sponsors/ahocevar"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1651,6 +1710,12 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
@@ -1663,6 +1728,23 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-draw": {
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.20.6.tgz",
+      "integrity": "sha512-mGypDjJNrrnVpfKfGYovNBuJZXSk39ClOdUJe/5dB5Cj3f2BGQlY9txyV4UmUxZCbc96aq+FMwrGZeM4BokhHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.5.2",
+        "react": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-leaflet-google-layer": {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,18 @@
     "backend": "node server.js"
   },
   "dependencies": {
+    "express": "^4.19.2",
+    "geojson": "^0.5.0",
+    "jszip": "^3.10.1",
+    "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "geojson": "^0.5.0",
-    "shpjs": "^6.1.0",
-    "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
+    "react-leaflet-draw": "^0.20.6",
     "react-leaflet-google-layer": "^4.0.0",
-    "jszip": "^3.10.1",
-    "express": "^4.19.2"
+    "shpjs": "^6.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- add **leaflet-draw** and **react-leaflet-draw** dependencies
- load leaflet.draw styles
- implement `LodUpload` component for uploading Limit of Disturbance polygons
- handle LOD polygon layer with drawing tools in `MapComponent`
- display and manage the LOD layer in `InfoPanel`
- update `App` to wire everything up

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fe54b215c8320ace1782107ffcdcc