### PR TITLE
Add polygon editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [zoomToLayer, setZoomToLayer] = useState<{ id: string; ts: number } | null>(null);
+  const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
@@ -78,6 +79,10 @@ const App: React.FC = () => {
     setZoomToLayer({ id, ts: Date.now() });
   }, []);
 
+  const handleToggleEditLayer = useCallback((id: string) => {
+    setEditingLayerId(prev => (prev === id ? null : id));
+  }, []);
+
   const handleUpdateFeatureHsg = useCallback<UpdateHsgFn>((layerId, featureIndex, hsg) => {
     setLayers(prev => prev.map(layer => {
       if (layer.id !== layerId) return layer;
@@ -108,6 +113,8 @@ const App: React.FC = () => {
             logs={logs}
             onRemoveLayer={handleRemoveLayer}
             onZoomToLayer={handleZoomToLayer}
+            onToggleEditLayer={handleToggleEditLayer}
+            editingLayerId={editingLayerId}
           />
         </aside>
         <main className="flex-1 bg-gray-900 h-full">
@@ -116,6 +123,10 @@ const App: React.FC = () => {
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
               zoomToLayer={zoomToLayer}
+              editingLayerId={editingLayerId}
+              onLayerGeoJsonChange={(id, geojson) => {
+                setLayers(prev => prev.map(l => l.id === id ? { ...l, geojson } : l));
+              }}
             />
           ) : (
             <InstructionsPage />

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -45,3 +45,9 @@ export const SearchIcon: React.FC<IconProps> = ({ className }) => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
   </svg>
 );
+
+export const PencilIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5l8 8m-6-6l-8 8-2 6 6-2 8-8" />
+  </svg>
+);

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
-import { XCircleIcon, InfoIcon, TrashIcon } from './Icons';
+import { XCircleIcon, InfoIcon, TrashIcon, PencilIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
@@ -9,9 +9,11 @@ interface InfoPanelProps {
   logs: LogEntry[];
   onRemoveLayer: (id: string) => void;
   onZoomToLayer?: (id: string) => void;
+  onToggleEditLayer?: (id: string) => void;
+  editingLayerId?: string | null;
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer }) => {
+const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer, onToggleEditLayer, editingLayerId }) => {
 
   const getFeatureTypeSummary = (geojson: LayerData['geojson']) => {
     if (!geojson) return {};
@@ -57,9 +59,16 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                   className="bg-gray-800 p-4 rounded-lg border border-gray-600/50 cursor-pointer hover:border-cyan-400"
                   onClick={() => onZoomToLayer && onZoomToLayer(layer.id)}
                 >
-                  <div className="flex justify-between items-start">
-                    <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
-                    <button onClick={() => onRemoveLayer(layer.id)} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
+                  <div className="flex justify-between items-start space-x-2">
+                    <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2 flex-1">{layer.name}</h3>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onToggleEditLayer && onToggleEditLayer(layer.id); }}
+                      className={`text-gray-500 hover:text-cyan-400 transition-colors flex-shrink-0 ${editingLayerId === layer.id ? 'text-cyan-400' : ''}`}
+                      aria-label={editingLayerId === layer.id ? `Stop editing ${layer.name}` : `Edit layer ${layer.name}`}
+                    >
+                      <PencilIcon className="w-5 h-5" />
+                    </button>
+                    <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
                       <TrashIcon className="w-5 h-5" />
                     </button>
                   </div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css"/>
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {
@@ -26,7 +27,10 @@
     "shpjs": "https://esm.sh/shpjs@^6.1.0",
     "leaflet": "https://esm.sh/leaflet@^1.9.4",
     "react-leaflet": "https://esm.sh/react-leaflet@^5.0.0",
-    "jszip": "https://esm.sh/jszip@^3.10.1"
+    "jszip": "https://esm.sh/jszip@^3.10.1",
+    "leaflet-draw": "https://esm.sh/leaflet-draw@^1.0.4",
+    "react-leaflet-draw": "https://esm.sh/react-leaflet-draw@^0.20.6",
+    "prop-types": "https://esm.sh/prop-types@^15.8.1"
   }
 }
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
+        "react-leaflet-draw": "^0.20.6",
         "react-leaflet-google-layer": "^4.0.0",
         "shpjs": "^6.1.0"
       },
@@ -3444,6 +3447,12 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/jsts": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
@@ -3471,6 +3480,12 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
+    },
     "node_modules/leaflet.gridlayer.googlemutant": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz",
@@ -3484,6 +3499,24 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/marchingsquares": {
@@ -3599,6 +3632,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -3751,6 +3793,17 @@
         "url": "https://github.com/sponsors/ahocevar"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3839,6 +3892,12 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
@@ -3851,6 +3910,23 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-draw": {
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.20.6.tgz",
+      "integrity": "sha512-mGypDjJNrrnVpfKfGYovNBuJZXSk39ClOdUJe/5dB5Cj3f2BGQlY9txyV4UmUxZCbc96aq+FMwrGZeM4BokhHQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "leaflet-draw": "^1.0.4",
+        "prop-types": "^15.5.2",
+        "react": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-leaflet-google-layer": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "geojson": "^0.5.0",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
+    "react-leaflet-draw": "^0.20.6",
     "react-leaflet-google-layer": "^4.0.0",
     "shpjs": "^6.1.0"
   },


### PR DESCRIPTION
## Summary
- add leafet-draw and react-leaflet-draw dependencies
- update icon set with PencilIcon
- support toggling edit mode in InfoPanel
- implement editable GeoJSON layers in MapComponent using EditControl
- wire up edit mode management in App
- include leaflet-draw CSS and import map entries

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ff155d03c8320a864c4e13314b426