### PR TITLE
Add selective polygon editing

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -40,6 +40,12 @@ export const TrashIcon: React.FC<IconProps> = ({ className }) => (
     </svg>
 );
 
+export const EditIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5h2m-1 0v9m-6.707.707l-.707.707a1 1 0 101.414 1.414l.707-.707M16.414 4.586a2 2 0 112.828 2.828l-10 10-4 1 1-4 10-10z" />
+  </svg>
+);
+
 export const SearchIcon: React.FC<IconProps> = ({ className }) => (
   <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
-import { XCircleIcon, InfoIcon, TrashIcon } from './Icons';
+import { XCircleIcon, InfoIcon, TrashIcon, EditIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
@@ -9,9 +9,11 @@ interface InfoPanelProps {
   logs: LogEntry[];
   onRemoveLayer: (id: string) => void;
   onZoomToLayer?: (id: string) => void;
+  onToggleEditLayer?: (id: string) => void;
+  editingLayerId?: string | null;
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer }) => {
+const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer, onToggleEditLayer, editingLayerId }) => {
 
   const getFeatureTypeSummary = (geojson: LayerData['geojson']) => {
     if (!geojson) return {};
@@ -59,9 +61,20 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                 >
                   <div className="flex justify-between items-start">
                     <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
-                    <button onClick={() => onRemoveLayer(layer.id)} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
-                      <TrashIcon className="w-5 h-5" />
-                    </button>
+                    <div className="flex space-x-2">
+                      {onToggleEditLayer && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
+                          className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
+                          aria-label={`Edit layer ${layer.name}`}
+                        >
+                          {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
+                        </button>
+                      )}
+                      <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
+                        <TrashIcon className="w-5 h-5" />
+                      </button>
+                    </div>
                   </div>
                   <div className="text-gray-300 space-y-2 text-sm">
                      <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{featureCount}</span></p>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@turf/turf": "^7.2.0",
+        "@types/leaflet-draw": "^1.0.12",
         "express": "^4.19.2",
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
@@ -2802,6 +2804,15 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/leaflet-draw": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-draw/-/leaflet-draw-1.0.12.tgz",
+      "integrity": "sha512-ayjGxelc3pp7532852Qn/LYHs/CHOcUqM9iDVsXuIXbIGfM2h3OtsHO/sQzFO6GAz2IvslPupgJaYocsY8NH+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
     "node_modules/@types/leaflet.gridlayer.googlemutant": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/@types/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.4.9.tgz",
@@ -3470,6 +3481,12 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
     },
     "node_modules/leaflet.gridlayer.googlemutant": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@turf/turf": "^7.2.0",
+    "@types/leaflet-draw": "^1.0.12",
     "express": "^4.19.2",
     "geojson": "^0.5.0",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
## Summary
- let user pick a polygon to edit instead of editing the whole layer
- recompute polygon area when geometry changes
- show hint message while waiting for polygon selection

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ff155d03c8320a864c4e13314b426