### PR TITLE
Add selective polygon editing

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -40,6 +40,12 @@ export const TrashIcon: React.FC<IconProps> = ({ className }) => (
     </svg>
 );
 
+export const EditIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5h2m-1 0v9m-6.707.707l-.707.707a1 1 0 101.414 1.414l.707-.707M16.414 4.586a2 2 0 112.828 2.828l-10 10-4 1 1-4 10-10z" />
+  </svg>
+);
+
 export const SearchIcon: React.FC<IconProps> = ({ className }) => (
   <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
-import { XCircleIcon, InfoIcon, TrashIcon } from './Icons';
+import { XCircleIcon, InfoIcon, TrashIcon, EditIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
@@ -9,9 +9,11 @@ interface InfoPanelProps {
   logs: LogEntry[];
   onRemoveLayer: (id: string) => void;
   onZoomToLayer?: (id: string) => void;
+  onToggleEditLayer?: (id: string) => void;
+  editingLayerId?: string | null;
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer }) => {
+const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer, onToggleEditLayer, editingLayerId }) => {
 
   const getFeatureTypeSummary = (geojson: LayerData['geojson']) => {
     if (!geojson) return {};
@@ -59,9 +61,20 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                 >
                   <div className="flex justify-between items-start">
                     <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
-                    <button onClick={() => onRemoveLayer(layer.id)} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
-                      <TrashIcon className="w-5 h-5" />
-                    </button>
+                    <div className="flex space-x-2">
+                      {onToggleEditLayer && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
+                          className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
+                          aria-label={`Edit layer ${layer.name}`}
+                        >
+                          {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
+                        </button>
+                      )}
+                      <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
+                        <TrashIcon className="w-5 h-5" />
+                      </button>
+                    </div>
                   </div>
                   <div className="text-gray-300 space-y-2 text-sm">
                      <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{featureCount}</span></p>

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
 import L from 'leaflet';
+import 'leaflet-draw';
 import { area as turfArea } from '@turf/turf';
 import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
@@ -13,6 +14,9 @@ interface MapComponentProps {
   layers: LayerData[];
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
   zoomToLayer?: { id: string; ts: number } | null;
+  editingTarget?: { layerId: string | null; featureIndex: number | null };
+  onSelectFeatureForEditing?: (layerId: string, index: number) => void;
+  onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -22,14 +26,50 @@ const ManagedGeoJsonLayer = ({
   data,
   isLastAdded,
   onUpdateFeatureHsg,
+  isEditingLayer,
+  editingFeatureIndex,
+  onSelectFeature,
+  onUpdateLayerGeojson,
 }: {
   id: string;
   data: LayerData['geojson'];
   isLastAdded: boolean;
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
+  isEditingLayer: boolean;
+  editingFeatureIndex: number | null;
+  onSelectFeature?: (index: number) => void;
+  onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
 }) => {
   const geoJsonRef = useRef<LeafletGeoJSON | null>(null);
   const map = useMap();
+
+  // Enable or disable vertex editing based on `isEditingLayer` and `editingFeatureIndex`
+  useEffect(() => {
+    if (!geoJsonRef.current) return;
+    geoJsonRef.current.eachLayer((layer: any) => {
+      if (layer.editing && typeof layer.editing.enable === 'function') {
+        const idx = data.features.indexOf(layer.feature as any);
+        if (isEditingLayer && editingFeatureIndex === idx) {
+          layer.editing.enable();
+        } else {
+          layer.editing.disable();
+        }
+      }
+    });
+  }, [isEditingLayer, editingFeatureIndex, data]);
+
+  // When geometry is edited, propagate changes up
+  useEffect(() => {
+    if (!geoJsonRef.current || !onUpdateLayerGeojson) return;
+    const handler = () => {
+      const updated = geoJsonRef.current!.toGeoJSON() as LayerData['geojson'];
+      onUpdateLayerGeojson(id, updated);
+    };
+    geoJsonRef.current.on('edit', handler);
+    return () => {
+      geoJsonRef.current?.off('edit', handler);
+    };
+  }, [id, onUpdateLayerGeojson]);
 
   const onEachFeature = (feature: GeoJSON.Feature, layer: Layer) => {
     if (feature.properties) {
@@ -51,7 +91,8 @@ const ManagedGeoJsonLayer = ({
       const areaRow = L.DomUtil.create('div', '', propsDiv);
       const updateArea = () => {
         try {
-          const areaSqM = turfArea(feature as any);
+          const poly = layer.toGeoJSON() as any;
+          const areaSqM = turfArea(poly);
           const areaSqFt = areaSqM * 10.7639;
           const areaAc = areaSqM / 4046.8564224;
           areaRow.innerHTML = `<b>Area:</b> ${areaSqFt.toLocaleString(undefined, { maximumFractionDigits: 2 })} sf (${areaAc.toLocaleString(undefined, { maximumFractionDigits: 4 })} ac)`;
@@ -61,6 +102,7 @@ const ManagedGeoJsonLayer = ({
       };
       updateArea();
       layer.on('popupopen', updateArea);
+      layer.on('edit', updateArea);
 
       // Special editable field for HSG
       if ('HSG' in feature.properties) {
@@ -87,7 +129,18 @@ const ManagedGeoJsonLayer = ({
         });
       }
 
-      layer.bindPopup(container);
+        const idx = data.features.indexOf(feature);
+        if (!(isEditingLayer && editingFeatureIndex === idx)) {
+          layer.bindPopup(container);
+        }
+
+      if (isEditingLayer && editingFeatureIndex === null && onSelectFeature) {
+        const handler = () => {
+          const idx = data.features.indexOf(feature);
+          onSelectFeature(idx);
+        };
+        layer.once('click', handler);
+      }
     }
   };
 
@@ -111,7 +164,7 @@ const ManagedGeoJsonLayer = ({
 
   return (
     <GeoJSON
-      key={id}
+      key={`${id}-${isEditingLayer ? editingFeatureIndex ?? 'pick' : 'view'}`}
       data={data}
       style={geoJsonStyle}
       onEachFeature={onEachFeature}
@@ -137,13 +190,18 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer }) => {
+const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
       <div className="absolute top-2 left-2 z-[1000] w-64">
         <AddressSearch />
       </div>
+      {editingTarget?.layerId && editingTarget.featureIndex === null && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
+          Haz clic en un polígono para editarlo
+        </div>
+      )}
       <LayersControl position="topright">
         {/* Base Layers */}
         <LayersControl.BaseLayer checked name="Dark">
@@ -198,6 +256,10 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
                 data={layer.geojson}
                 isLastAdded={index === layers.length - 1}
                 onUpdateFeatureHsg={onUpdateFeatureHsg}
+                isEditingLayer={editingTarget?.layerId === layer.id}
+                editingFeatureIndex={editingTarget?.layerId === layer.id ? editingTarget.featureIndex : null}
+                onSelectFeature={idx => onSelectFeatureForEditing && onSelectFeatureForEditing(layer.id, idx)}
+                onUpdateLayerGeojson={onUpdateLayerGeojson}
              />
           </LayersControl.Overlay>
         ))}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@turf/turf": "^7.2.0",
+        "@types/leaflet-draw": "^1.0.12",
         "express": "^4.19.2",
         "geojson": "^0.5.0",
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
@@ -2802,6 +2804,15 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/leaflet-draw": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-draw/-/leaflet-draw-1.0.12.tgz",
+      "integrity": "sha512-ayjGxelc3pp7532852Qn/LYHs/CHOcUqM9iDVsXuIXbIGfM2h3OtsHO/sQzFO6GAz2IvslPupgJaYocsY8NH+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
     "node_modules/@types/leaflet.gridlayer.googlemutant": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/@types/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.4.9.tgz",
@@ -3470,6 +3481,12 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT"
     },
     "node_modules/leaflet.gridlayer.googlemutant": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@turf/turf": "^7.2.0",
+    "@types/leaflet-draw": "^1.0.12",
     "express": "^4.19.2",
     "geojson": "^0.5.0",
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
## Summary
- let user pick a polygon to edit instead of editing the whole layer
- recompute polygon area when geometry changes
- show hint message while waiting for polygon selection
- hide polygon attributes while editing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ff155d03c8320a864c4e13314b426