### PR TITLE
Fix polygon edit workflow

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -47,12 +47,21 @@ const ManagedGeoJsonLayer = ({
   useEffect(() => {
     if (!geoJsonRef.current) return;
     geoJsonRef.current.eachLayer((layer: any) => {
+      const idx = data.features.indexOf(layer.feature as any);
+      const shouldEdit = isEditingLayer && editingFeatureIndex === idx;
+
       if (layer.editing && typeof layer.editing.enable === 'function') {
-        const idx = data.features.indexOf(layer.feature as any);
-        if (isEditingLayer && editingFeatureIndex === idx) {
-          layer.editing.enable();
-        } else {
-          layer.editing.disable();
+        shouldEdit ? layer.editing.enable() : layer.editing.disable();
+      }
+
+      if (shouldEdit) {
+        if (layer.getPopup()) {
+          layer.closePopup();
+          layer.unbindPopup();
+        }
+      } else {
+        if (!layer.getPopup() && (layer as any)._originalPopupContent) {
+          layer.bindPopup((layer as any)._originalPopupContent);
         }
       }
     });
@@ -130,6 +139,7 @@ const ManagedGeoJsonLayer = ({
       }
 
       layer.bindPopup(container);
+      (layer as any)._originalPopupContent = container;
 
       if (isEditingLayer && editingFeatureIndex === null && onSelectFeature) {
         const handler = () => {
@@ -188,6 +198,8 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
 };
 
 const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+  const visibleLayers = editingTarget?.layerId ? layers.filter(l => l.id === editingTarget.layerId) : layers;
+
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
@@ -246,12 +258,12 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
         </LayersControl.BaseLayer>
 
         {/* Overlay Layers */}
-        {layers.map((layer, index) => (
+        {visibleLayers.map((layer, index) => (
           <LayersControl.Overlay checked name={layer.name} key={layer.id}>
              <ManagedGeoJsonLayer
                 id={layer.id}
                 data={layer.geojson}
-                isLastAdded={index === layers.length - 1}
+                isLastAdded={index === visibleLayers.length - 1}
                 onUpdateFeatureHsg={onUpdateFeatureHsg}
                 isEditingLayer={editingTarget?.layerId === layer.id}
                 editingFeatureIndex={editingTarget?.layerId === layer.id ? editingTarget.featureIndex : null}


### PR DESCRIPTION
## Summary
- isolate target layer while editing
- disable popups during vertex editing
- rebind popups when editing ends

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68700912262c8320b5fbddc719adc0e7