### PR TITLE
Fix shapefile editing workflow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -93,9 +93,12 @@ const App: React.FC = () => {
   }, [addLog]);
 
   const handleToggleEditLayer = useCallback((id: string) => {
-    setEditingTarget(prev => prev.layerId === id ? { layerId: null, featureIndex: null } : { layerId: id, featureIndex: null });
-    if (editingTarget.layerId !== id) {
-      addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+    const turningOff = editingTarget.layerId === id;
+    setEditingTarget(prev => turningOff ? { layerId: null, featureIndex: null } : { layerId: id, featureIndex: null });
+    if (turningOff) {
+      addLog(`Finalizada la edición de ${id}`);
+    } else {
+      addLog(`Selecciona un polígono de ${id} para editarlo`);
     }
   }, [addLog, editingTarget.layerId]);
 


### PR DESCRIPTION
## Summary
- allow vertex editing of a polygon from its popup
- instruct users to use the popup button when editing a layer
- finalize geometry and log when editing is disabled

## Testing
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68700b6fe7b88320a086f917501da700