### PR TITLE
Remove User-Agent header from address search

### DIFF
--- a/components/AddressSearch.tsx
+++ b/components/AddressSearch.tsx
@@ -30,7 +30,7 @@ const AddressSearch: React.FC = () => {
         limit: '1'
       });
       const res = await fetch(`${NOMINATIM_URL}?${params.toString()}`, {
-        headers: { 'Accept-Language': 'en', 'User-Agent': 'shapefile-viewer-pro' }
+        headers: { 'Accept-Language': 'en' }
       });
       if (res.ok) {
         const data = await res.json();


### PR DESCRIPTION
## Summary
- update address search to stop setting a `User-Agent`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870122b9c748320808e78c9eea6f13c