### PR TITLE
Add log trimming to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This contains everything you need to run your app locally.
    `npm run dev`
 4. Start the backend server in another terminal:
    `npm run backend`
+   You can control how many log entries the server keeps by setting the
+   `LOG_LIMIT` environment variable (defaults to `100`).
 
 ## Geospatial utilities
 

--- a/server.js
+++ b/server.js
@@ -10,11 +10,15 @@ const __dirname = path.dirname(__filename);
 const app = express();
 app.use(express.json());
 const port = process.env.PORT || 3001;
+const logLimit = parseInt(process.env.LOG_LIMIT || '100', 10);
 
 const logs = [];
 function addLog(message, type = 'info') {
   const entry = { message, type, source: 'backend', timestamp: Date.now() };
   logs.push(entry);
+  if (logs.length > logLimit) {
+    logs.splice(0, logs.length - logLimit);
+  }
   console.log(`[${entry.type.toUpperCase()}] ${entry.message}`);
 }
 


### PR DESCRIPTION
## Summary
- keep only the newest logs with a configurable `LOG_LIMIT`
- document the `LOG_LIMIT` environment variable

## Testing
- `npm install`
- `LOG_LIMIT=5 node server.js` and fetch `/api/soil-hsg-map` then `/api/logs`

------
https://chatgpt.com/codex/tasks/task_e_68701235336083208934331e853228fa