### PR TITLE
Expose CN data via backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The backend exposes two endpoints using Turf.js for polygon processing:
   their intersection or `null` if they do not overlap.
 * `POST /api/area` accepts `{ polygon }` and returns `{ area }` in square meters.
 
+An additional route serves SCS Curve Number lookup data used for hydrologic
+analysis:
+
+* `GET /api/cn-values` returns the contents of `public/data/SCS_CN_VALUES.json`.
+
+This allows the frontend to fetch the table of CN values based on soil group.
+
 These routes are ready for future integration with the frontend.
 
 ## Update soil HSG mapping

--- a/public/data/SCS_CN_VALUES.json
+++ b/public/data/SCS_CN_VALUES.json
@@ -406,14 +406,14 @@
     "D": 89
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 49,
     "B": 69,
     "C": 79,
     "D": 84
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 39,
     "B": 61,
     "C": 74,
@@ -434,14 +434,14 @@
     "D": 83
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 35,
     "B": 56,
     "C": 70,
     "D": 77
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 30,
     "B": 48,
     "C": 65,
@@ -455,14 +455,14 @@
     "D": 86
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 43,
     "B": 65,
     "C": 76,
     "D": 82
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 32,
     "B": 58,
     "C": 72,
@@ -476,14 +476,14 @@
     "D": 83
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 36,
     "B": 60,
     "C": 73,
     "D": 79
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 30,
     "B": 55,
     "C": 70,
@@ -504,14 +504,14 @@
     "D": 88
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 55,
     "B": 72,
     "C": 81,
     "D": 86
   },
   {
-    "Description": "nan",
+    "Description": "Unknown",
     "A": 49,
     "B": 68,
     "C": 79,

--- a/server.js
+++ b/server.js
@@ -45,6 +45,19 @@ app.get('/api/soil-hsg-map', (req, res) => {
   });
 });
 
+app.get('/api/cn-values', (req, res) => {
+  const filePath = path.join(__dirname, 'public', 'data', 'SCS_CN_VALUES.json');
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      addLog('Error reading CN values', 'error');
+      res.status(500).send('Unable to read CN values');
+    } else {
+      addLog('Curve Number values served');
+      res.type('application/json').send(data);
+    }
+  });
+});
+
 app.get('/api/logs', (req, res) => {
   res.json(logs);
 });


### PR DESCRIPTION
## Summary
- move `SCS_CN_VALUES_clean.json` into `public/data` and rename to `SCS_CN_VALUES.json`
- serve curve number data at new `/api/cn-values` endpoint
- sanitize descriptions labelled as `nan`
- document the new route in README

## Testing
- `node --test tests/intersect.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68701b626ea88320af0a571d0cdee62b