### PR TITLE
Add save/discard controls for shapefile editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import type { FeatureCollection } from 'geojson';
 import type { LayerData, LogEntry } from './types';
 import Header from './components/Header';
@@ -16,6 +16,16 @@ const App: React.FC = () => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [zoomToLayer, setZoomToLayer] = useState<{ id: string; ts: number } | null>(null);
   const [editingTarget, setEditingTarget] = useState<{ layerId: string | null; featureIndex: number | null }>({ layerId: null, featureIndex: null });
+  const [editingDraft, setEditingDraft] = useState<
+    { id: string; original: FeatureCollection; geojson: FeatureCollection } | null
+  >(null);
+
+  const mapLayers = useMemo(() => {
+    if (!editingDraft) return layers;
+    return layers.map(l =>
+      l.id === editingDraft.id ? { ...l, geojson: editingDraft.geojson } : l
+    );
+  }, [layers, editingDraft]);
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
@@ -73,7 +83,10 @@ const App: React.FC = () => {
   const handleRemoveLayer = useCallback((id: string) => {
     setLayers(prevLayers => prevLayers.filter(layer => layer.id !== id));
     addLog(`Removed layer ${id}`);
-    if (editingTarget.layerId === id) setEditingTarget({ layerId: null, featureIndex: null });
+    if (editingTarget.layerId === id) {
+      setEditingTarget({ layerId: null, featureIndex: null });
+      setEditingDraft(null);
+    }
   }, [addLog, editingTarget]);
 
   const handleZoomToLayer = useCallback((id: string) => {
@@ -93,21 +106,49 @@ const App: React.FC = () => {
   }, [addLog]);
 
   const handleToggleEditLayer = useCallback((id: string) => {
-    setEditingTarget(prev => prev.layerId === id ? { layerId: null, featureIndex: null } : { layerId: id, featureIndex: null });
-    if (editingTarget.layerId !== id) {
-      addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
-    }
-  }, [addLog, editingTarget.layerId]);
+    if (editingDraft) return;
+    const layer = layers.find(l => l.id === id);
+    if (!layer) return;
+    const snapshot = JSON.parse(JSON.stringify(layer.geojson)) as FeatureCollection;
+    setEditingDraft({ id, original: snapshot, geojson: snapshot });
+    setEditingTarget({ layerId: id, featureIndex: null });
+    addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+  }, [addLog, layers, editingDraft]);
 
   const handleSelectFeatureForEditing = useCallback((layerId: string, index: number) => {
     setEditingTarget({ layerId, featureIndex: index });
     addLog(`Editando pol\u00edgono ${index} en ${layerId}`);
   }, [addLog]);
 
-  const handleUpdateLayerGeojson = useCallback((id: string, geojson: FeatureCollection) => {
-    setLayers(prev => prev.map(layer => layer.id === id ? { ...layer, geojson } : layer));
-    addLog(`Updated geometry for layer ${id}`);
-  }, [addLog]);
+  const handleUpdateLayerGeojson = useCallback(
+    (id: string, geojson: FeatureCollection) => {
+      if (editingDraft && editingDraft.id === id) {
+        setEditingDraft({ ...editingDraft, geojson });
+      } else {
+        setLayers(prev =>
+          prev.map(layer => (layer.id === id ? { ...layer, geojson } : layer))
+        );
+      }
+      addLog(`Updated geometry for layer ${id}`);
+    },
+    [addLog, editingDraft]
+  );
+
+  const handleSaveEditLayer = useCallback(() => {
+    if (!editingDraft) return;
+    setLayers(prev => prev.map(l => l.id === editingDraft.id ? { ...l, geojson: editingDraft.geojson } : l));
+    addLog(`Saved edits to layer ${editingDraft.id}`);
+    setEditingDraft(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+  }, [editingDraft, addLog]);
+
+  const handleDiscardEditLayer = useCallback(() => {
+    if (!editingDraft) return;
+    setLayers(prev => prev.map(l => l.id === editingDraft.id ? { ...l, geojson: editingDraft.original } : l));
+    addLog(`Discarded edits to layer ${editingDraft.id}`);
+    setEditingDraft(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+  }, [editingDraft, addLog]);
 
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
@@ -128,13 +169,15 @@ const App: React.FC = () => {
             onRemoveLayer={handleRemoveLayer}
             onZoomToLayer={handleZoomToLayer}
             onToggleEditLayer={handleToggleEditLayer}
+            onSaveEditLayer={handleSaveEditLayer}
+            onDiscardEditLayer={handleDiscardEditLayer}
             editingLayerId={editingTarget.layerId}
           />
         </aside>
         <main className="flex-1 bg-gray-900 h-full">
-          {layers.length > 0 ? (
+          {mapLayers.length > 0 ? (
             <MapComponent
-              layers={layers}
+              layers={mapLayers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
-import { XCircleIcon, InfoIcon, TrashIcon, EditIcon } from './Icons';
+import { XCircleIcon, InfoIcon, TrashIcon, EditIcon, CheckCircleIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
@@ -10,10 +10,12 @@ interface InfoPanelProps {
   onRemoveLayer: (id: string) => void;
   onZoomToLayer?: (id: string) => void;
   onToggleEditLayer?: (id: string) => void;
+  onSaveEditLayer?: () => void;
+  onDiscardEditLayer?: () => void;
   editingLayerId?: string | null;
 }
 
-const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer, onToggleEditLayer, editingLayerId }) => {
+const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLayer, onZoomToLayer, onToggleEditLayer, onSaveEditLayer, onDiscardEditLayer, editingLayerId }) => {
 
   const getFeatureTypeSummary = (geojson: LayerData['geojson']) => {
     if (!geojson) return {};
@@ -62,15 +64,32 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                   <div className="flex justify-between items-start">
                     <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
                     <div className="flex space-x-2">
-                      {onToggleEditLayer && (
+                      {editingLayerId === layer.id && onSaveEditLayer && onDiscardEditLayer ? (
+                        <>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); onSaveEditLayer(); }}
+                            className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
+                            aria-label={`Save edits to ${layer.name}`}
+                          >
+                            <CheckCircleIcon className="w-5 h-5" />
+                          </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); onDiscardEditLayer(); }}
+                            className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0"
+                            aria-label={`Discard edits to ${layer.name}`}
+                          >
+                            <XCircleIcon className="w-5 h-5" />
+                          </button>
+                        </>
+                      ) : onToggleEditLayer ? (
                         <button
                           onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
                           className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
                           aria-label={`Edit layer ${layer.name}`}
                         >
-                          {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
+                          <EditIcon className="w-5 h-5" />
                         </button>
-                      )}
+                      ) : null}
                       <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
                         <TrashIcon className="w-5 h-5" />
                       </button>


### PR DESCRIPTION
## Summary
- implement geometry snapshot when starting edit mode
- restore original geometry on discard
- keep edited geometry on save

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687023fd12f48320a30ee105caeeabee