### PR TITLE
Add non destructive polygon editing

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -17,6 +17,8 @@ interface MapComponentProps {
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onSaveEdits?: (id: string) => void;
+  onDiscardEdits?: (id: string) => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -204,13 +206,29 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson, onSaveEdits, onDiscardEdits }) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
       <div className="absolute top-2 left-2 z-[1000] w-64">
         <AddressSearch />
       </div>
+      {editingTarget?.layerId && (
+        <div className="absolute top-2 right-2 z-[1000] flex space-x-2">
+          <button
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+            onClick={() => onSaveEdits && onSaveEdits(editingTarget.layerId!)}
+          >
+            Guardar
+          </button>
+          <button
+            className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded"
+            onClick={() => onDiscardEdits && onDiscardEdits(editingTarget.layerId!)}
+          >
+            Descartar
+          </button>
+        </div>
+      )}
       {editingTarget?.layerId && editingTarget.featureIndex === null && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
           Haz clic en un polígono para editarlo

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,8 @@ export interface LayerData {
   id: string;
   name: string;
   geojson: FeatureCollection;
+  /** Original data preserved when editing is enabled */
+  originalGeojson?: FeatureCollection;
 }
 
 export interface LogEntry {


### PR DESCRIPTION
## Summary
- keep a copy of shapefile data when editing begins
- provide Save and Discard actions for editing
- display Save/Discard controls in the map UI

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687035a79a108320a60d4a84e640a357