### PR TITLE
Implement non-destructive editing controls

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -17,6 +17,8 @@ interface MapComponentProps {
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onSaveEdits?: (id: string) => void;
+  onDiscardEdits?: (id: string) => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -204,18 +206,34 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson, onSaveEdits, onDiscardEdits }) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
-      <div className="absolute top-2 left-2 z-[1000] w-64">
-        <AddressSearch />
-      </div>
-      {editingTarget?.layerId && editingTarget.featureIndex === null && (
-        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
-          Haz clic en un polígono para editarlo
-        </div>
-      )}
+  <div className="absolute top-2 left-2 z-[1000] w-64">
+    <AddressSearch />
+  </div>
+  {editingTarget?.layerId && editingTarget.featureIndex === null && (
+    <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
+      Haz clic en un polígono para editarlo
+    </div>
+  )}
+  {editingTarget?.layerId && (
+    <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-[1000] space-x-2">
+      <button
+        onClick={() => onSaveEdits && onSaveEdits(editingTarget.layerId!)}
+        className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
+      >
+        Guardar
+      </button>
+      <button
+        onClick={() => onDiscardEdits && onDiscardEdits(editingTarget.layerId!)}
+        className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded"
+      >
+        Descartar
+      </button>
+    </div>
+  )}
       <LayersControl position="topright">
         {/* Base Layers */}
         <LayersControl.BaseLayer checked name="Dark">

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
         "typescript": "~5.7.2",
         "vite": "^6.2.0"
       }
@@ -2832,6 +2834,26 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2986,6 +3008,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
## Summary
- keep a backup of original geometry when entering edit mode
- allow saving or discarding polygon edits
- show Save/Discard controls on the map
- update dependencies for React type definitions

## Testing
- `npx tsc --noEmit` *(fails: several type errors)*

------
https://chatgpt.com/codex/tasks/task_e_687035a79a108320a60d4a84e640a357