### PR TITLE
Add non-destructive polygon editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import type { FeatureCollection } from 'geojson';
 import type { LayerData, LogEntry } from './types';
 import Header from './components/Header';
@@ -16,6 +16,8 @@ const App: React.FC = () => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [zoomToLayer, setZoomToLayer] = useState<{ id: string; ts: number } | null>(null);
   const [editingTarget, setEditingTarget] = useState<{ layerId: string | null; featureIndex: number | null }>({ layerId: null, featureIndex: null });
+  const [editingBackup, setEditingBackup] = useState<{ layerId: string; geojson: FeatureCollection } | null>(null);
+  const ignoreEditRef = useRef(false);
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
@@ -92,12 +94,41 @@ const App: React.FC = () => {
     addLog(`Set HSG for feature ${featureIndex} in ${layerId} to ${hsg}`);
   }, [addLog]);
 
-  const handleToggleEditLayer = useCallback((id: string) => {
-    setEditingTarget(prev => prev.layerId === id ? { layerId: null, featureIndex: null } : { layerId: id, featureIndex: null });
-    if (editingTarget.layerId !== id) {
-      addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+  const handleDiscardEditing = useCallback(() => {
+    if (!editingTarget.layerId) return;
+    const id = editingTarget.layerId;
+    if (editingBackup && editingBackup.layerId === id) {
+      setLayers(prev => prev.map(layer =>
+        layer.id === id ? { ...layer, geojson: JSON.parse(JSON.stringify(editingBackup.geojson)) } : layer
+      ));
     }
-  }, [addLog, editingTarget.layerId]);
+    ignoreEditRef.current = true;
+    setEditingBackup(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+    addLog(`Descartados los cambios en ${id}`);
+  }, [addLog, editingTarget, editingBackup]);
+
+  const handleSaveEditing = useCallback(() => {
+    if (!editingTarget.layerId) return;
+    const id = editingTarget.layerId;
+    setEditingBackup(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+    addLog(`Guardados los cambios en ${id}`);
+  }, [addLog, editingTarget]);
+
+  const handleToggleEditLayer = useCallback((id: string) => {
+    if (editingTarget.layerId === id) {
+      handleDiscardEditing();
+      return;
+    }
+    const layer = layers.find(l => l.id === id);
+    if (!layer) return;
+    setEditingBackup({ layerId: id, geojson: JSON.parse(JSON.stringify(layer.geojson)) });
+    const copy = JSON.parse(JSON.stringify(layer.geojson)) as FeatureCollection;
+    setLayers(prev => prev.map(l => l.id === id ? { ...l, geojson: copy } : l));
+    setEditingTarget({ layerId: id, featureIndex: null });
+    addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+  }, [addLog, editingTarget.layerId, layers, handleDiscardEditing]);
 
   const handleSelectFeatureForEditing = useCallback((layerId: string, index: number) => {
     setEditingTarget({ layerId, featureIndex: index });
@@ -105,6 +136,10 @@ const App: React.FC = () => {
   }, [addLog]);
 
   const handleUpdateLayerGeojson = useCallback((id: string, geojson: FeatureCollection) => {
+    if (ignoreEditRef.current) {
+      ignoreEditRef.current = false;
+      return;
+    }
     setLayers(prev => prev.map(layer => layer.id === id ? { ...layer, geojson } : layer));
     addLog(`Updated geometry for layer ${id}`);
   }, [addLog]);
@@ -140,6 +175,8 @@ const App: React.FC = () => {
               editingTarget={editingTarget}
               onSelectFeatureForEditing={handleSelectFeatureForEditing}
               onUpdateLayerGeojson={handleUpdateLayerGeojson}
+              onSaveEdits={handleSaveEditing}
+              onDiscardEdits={handleDiscardEditing}
             />
           ) : (
             <InstructionsPage />

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -17,6 +17,8 @@ interface MapComponentProps {
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onSaveEdits?: () => void;
+  onDiscardEdits?: () => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -204,7 +206,16 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+const MapComponent: React.FC<MapComponentProps> = ({
+  layers,
+  onUpdateFeatureHsg,
+  zoomToLayer,
+  editingTarget,
+  onSelectFeatureForEditing,
+  onUpdateLayerGeojson,
+  onSaveEdits,
+  onDiscardEdits,
+}) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
@@ -214,6 +225,22 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
       {editingTarget?.layerId && editingTarget.featureIndex === null && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
           Haz clic en un polígono para editarlo
+        </div>
+      )}
+      {editingTarget?.layerId && (
+        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-[1000] space-x-2">
+          <button
+            onClick={onSaveEdits}
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded shadow"
+          >
+            Guardar
+          </button>
+          <button
+            onClick={onDiscardEdits}
+            className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded shadow"
+          >
+            Descartar
+          </button>
         </div>
       )}
       <LayersControl position="topright">


### PR DESCRIPTION
## Summary
- duplicate layer data when starting edit mode
- allow saving or discarding geometry edits
- show Save and Discard controls on the map
- correctly discard edits by ignoring next geometry update

## Testing
- `node --test tests/intersect.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687035a79a108320a60d4a84e640a357