### PR TITLE
Add non-destructive polygon editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ const App: React.FC = () => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [zoomToLayer, setZoomToLayer] = useState<{ id: string; ts: number } | null>(null);
   const [editingTarget, setEditingTarget] = useState<{ layerId: string | null; featureIndex: number | null }>({ layerId: null, featureIndex: null });
+  const [editingBackup, setEditingBackup] = useState<{ layerId: string; geojson: FeatureCollection } | null>(null);
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
@@ -92,12 +93,38 @@ const App: React.FC = () => {
     addLog(`Set HSG for feature ${featureIndex} in ${layerId} to ${hsg}`);
   }, [addLog]);
 
-  const handleToggleEditLayer = useCallback((id: string) => {
-    setEditingTarget(prev => prev.layerId === id ? { layerId: null, featureIndex: null } : { layerId: id, featureIndex: null });
-    if (editingTarget.layerId !== id) {
-      addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+  const handleDiscardEditing = useCallback(() => {
+    if (!editingTarget.layerId) return;
+    const id = editingTarget.layerId;
+    if (editingBackup && editingBackup.layerId === id) {
+      setLayers(prev => prev.map(layer => layer.id === id ? { ...layer, geojson: editingBackup.geojson } : layer));
     }
-  }, [addLog, editingTarget.layerId]);
+    setEditingBackup(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+    addLog(`Descartados los cambios en ${id}`);
+  }, [addLog, editingTarget, editingBackup]);
+
+  const handleSaveEditing = useCallback(() => {
+    if (!editingTarget.layerId) return;
+    const id = editingTarget.layerId;
+    setEditingBackup(null);
+    setEditingTarget({ layerId: null, featureIndex: null });
+    addLog(`Guardados los cambios en ${id}`);
+  }, [addLog, editingTarget]);
+
+  const handleToggleEditLayer = useCallback((id: string) => {
+    if (editingTarget.layerId === id) {
+      handleDiscardEditing();
+      return;
+    }
+    const layer = layers.find(l => l.id === id);
+    if (!layer) return;
+    setEditingBackup({ layerId: id, geojson: JSON.parse(JSON.stringify(layer.geojson)) });
+    const copy = JSON.parse(JSON.stringify(layer.geojson)) as FeatureCollection;
+    setLayers(prev => prev.map(l => l.id === id ? { ...l, geojson: copy } : l));
+    setEditingTarget({ layerId: id, featureIndex: null });
+    addLog(`Selecciona un pol\u00edgono de ${id} para editarlo`);
+  }, [addLog, editingTarget.layerId, layers, handleDiscardEditing]);
 
   const handleSelectFeatureForEditing = useCallback((layerId: string, index: number) => {
     setEditingTarget({ layerId, featureIndex: index });
@@ -140,6 +167,8 @@ const App: React.FC = () => {
               editingTarget={editingTarget}
               onSelectFeatureForEditing={handleSelectFeatureForEditing}
               onUpdateLayerGeojson={handleUpdateLayerGeojson}
+              onSaveEdits={handleSaveEditing}
+              onDiscardEdits={handleDiscardEditing}
             />
           ) : (
             <InstructionsPage />

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -17,6 +17,8 @@ interface MapComponentProps {
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onSaveEdits?: () => void;
+  onDiscardEdits?: () => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -30,6 +32,7 @@ const ManagedGeoJsonLayer = ({
   editingFeatureIndex,
   onSelectFeature,
   onUpdateLayerGeojson,
+  onRef,
 }: {
   id: string;
   data: LayerData['geojson'];
@@ -39,6 +42,7 @@ const ManagedGeoJsonLayer = ({
   editingFeatureIndex: number | null;
   onSelectFeature?: (index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onRef?: (ref: LeafletGeoJSON | null) => void;
 }) => {
   const geoJsonRef = useRef<LeafletGeoJSON | null>(null);
   const map = useMap();
@@ -57,6 +61,13 @@ const ManagedGeoJsonLayer = ({
       }
     });
   }, [isEditingLayer, editingFeatureIndex, data]);
+
+  // Refresh geometry when `data` changes so edits or discards show immediately
+  useEffect(() => {
+    if (!geoJsonRef.current) return;
+    geoJsonRef.current.clearLayers();
+    geoJsonRef.current.addData(data as any);
+  }, [data]);
 
   // When entering selection mode for a layer, add click handlers to choose a feature
   useEffect(() => {
@@ -182,7 +193,10 @@ const ManagedGeoJsonLayer = ({
       data={data}
       style={geoJsonStyle}
       onEachFeature={onEachFeature}
-      ref={geoJsonRef}
+      ref={(el) => {
+        geoJsonRef.current = el;
+        if (onRef) onRef(el);
+      }}
     />
   );
 };
@@ -204,7 +218,28 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+const MapComponent: React.FC<MapComponentProps> = ({
+  layers,
+  onUpdateFeatureHsg,
+  zoomToLayer,
+  editingTarget,
+  onSelectFeatureForEditing,
+  onUpdateLayerGeojson,
+  onSaveEdits,
+  onDiscardEdits,
+}) => {
+  const layerRefs = useRef<Record<string, LeafletGeoJSON | null>>({});
+
+  const handleSaveClick = () => {
+    if (editingTarget?.layerId) {
+      const ref = layerRefs.current[editingTarget.layerId];
+      if (ref && onUpdateLayerGeojson) {
+        const updated = ref.toGeoJSON() as LayerData['geojson'];
+        onUpdateLayerGeojson(editingTarget.layerId, updated);
+      }
+    }
+    onSaveEdits?.();
+  };
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
@@ -214,6 +249,22 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
       {editingTarget?.layerId && editingTarget.featureIndex === null && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
           Haz clic en un polígono para editarlo
+        </div>
+      )}
+      {editingTarget?.layerId && (
+        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-[1000] space-x-2">
+          <button
+            onClick={handleSaveClick}
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded shadow"
+          >
+            Guardar
+          </button>
+          <button
+            onClick={onDiscardEdits}
+            className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded shadow"
+          >
+            Descartar
+          </button>
         </div>
       )}
       <LayersControl position="topright">
@@ -274,6 +325,7 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
                 editingFeatureIndex={editingTarget?.layerId === layer.id ? editingTarget.featureIndex : null}
                 onSelectFeature={idx => onSelectFeatureForEditing && onSelectFeatureForEditing(layer.id, idx)}
                 onUpdateLayerGeojson={onUpdateLayerGeojson}
+                onRef={el => { layerRefs.current[layer.id] = el; }}
              />
           </LayersControl.Overlay>
         ))}


### PR DESCRIPTION
## Summary
- duplicate layer data when starting edit mode
- allow saving or discarding geometry edits
- show Save and Discard controls on the map
- ensure geometry refreshes when edits are discarded
- refresh layer geometry before saving edits so further edits use the last saved state

## Testing
- `node --test tests/intersect.test.js` *(fails: fetch failed)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687035a79a108320a60d4a84e640a357