### PR TITLE
Add layer refresh on save and discard

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -17,6 +17,8 @@ interface MapComponentProps {
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
   onUpdateLayerGeojson?: (id: string, geojson: LayerData['geojson']) => void;
+  onSaveEdits?: () => void;
+  onDiscardEdits?: () => void;
 }
 
 // This component renders a single GeoJSON layer and handles the auto-zooming effect.
@@ -57,6 +59,13 @@ const ManagedGeoJsonLayer = ({
       }
     });
   }, [isEditingLayer, editingFeatureIndex, data]);
+
+  // Refresh geometry when `data` changes so edits or discards show immediately
+  useEffect(() => {
+    if (!geoJsonRef.current) return;
+    geoJsonRef.current.clearLayers();
+    geoJsonRef.current.addData(data as any);
+  }, [data]);
 
   // When entering selection mode for a layer, add click handlers to choose a feature
   useEffect(() => {
@@ -204,7 +213,16 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
-const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg, zoomToLayer, editingTarget, onSelectFeatureForEditing, onUpdateLayerGeojson }) => {
+const MapComponent: React.FC<MapComponentProps> = ({
+  layers,
+  onUpdateFeatureHsg,
+  zoomToLayer,
+  editingTarget,
+  onSelectFeatureForEditing,
+  onUpdateLayerGeojson,
+  onSaveEdits,
+  onDiscardEdits,
+}) => {
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
@@ -214,6 +232,22 @@ const MapComponent: React.FC<MapComponentProps> = ({ layers, onUpdateFeatureHsg,
       {editingTarget?.layerId && editingTarget.featureIndex === null && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-[1000] bg-gray-800/90 text-white px-3 py-1 rounded shadow">
           Haz clic en un polígono para editarlo
+        </div>
+      )}
+      {editingTarget?.layerId && (
+        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-[1000] space-x-2">
+          <button
+            onClick={onSaveEdits}
+            className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded shadow"
+          >
+            Guardar
+          </button>
+          <button
+            onClick={onDiscardEdits}
+            className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded shadow"
+          >
+            Descartar
+          </button>
         </div>
       )}
       <LayersControl position="topright">


### PR DESCRIPTION
## Summary
- add `refreshLayer` helper to clone layer geometry
- refresh geometry when saving or discarding edits so further edits use the latest version

## Testing
- `node --test tests/intersect.test.js` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_687035a79a108320a60d4a84e640a357