### PR TITLE
Improve polygon editing with snapping and overlap check

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
+    <link href="https://unpkg.com/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css" rel="stylesheet" />
     <style>
       /* Ensure leaflet map renders correctly */
       .leaflet-container {


### PR DESCRIPTION
## Summary
- switch to Leaflet‑Geoman editing
- enable snapping and anti self‑intersection
- check for polygon overlaps using Turf.js
- include Geoman CSS

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68713a90406083208eb5ea15e7b3d49f