### PR TITLE
Add cancel option for edit/drag

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -259,6 +259,9 @@ const GeomanControls = ({
     try {
       // changeControlOrder is only available in newer versions
       (map.pm as any).Toolbar.changeControlOrder(toolOrder);
+      // add cancel action next to finish for edit and drag modes
+      (map.pm as any).Toolbar.changeActionsOfControl('editMode', ['finishMode', 'cancel']);
+      (map.pm as any).Toolbar.changeActionsOfControl('dragMode', ['finishMode', 'cancel']);
     } catch {
       /* noop */
     }


### PR DESCRIPTION
## Summary
- add `cancel` sub-action to edit and drag modes so users can discard edits

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68714c98a34483209ef703f1d001b896