### PR TITLE
Fix: require opt-in editing for polygons

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -9,6 +9,9 @@ import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
 
+// Require explicit enabling of editing features
+L.PM.setOptIn(true);
+
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
 interface MapComponentProps {


### PR DESCRIPTION
## Summary
- disable Geoman editing for all polygons unless editing mode is activated

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6875713ff8ac83209de52c36fe854d9b