### PR TITLE
Restrict polygon vertex editing

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -226,6 +226,18 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
   return null;
 };
 
+const MapPmOptIn = () => {
+  const map = useMap();
+  useEffect(() => {
+    try {
+      (map.pm as any).setOptIn(true);
+    } catch {
+      /* noop */
+    }
+  }, [map]);
+  return null;
+};
+
 const GeomanControls = ({
   active,
   layer,
@@ -392,6 +404,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
   };
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
+      <MapPmOptIn />
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
       <GeomanControls
         active={!!editingTarget?.layerId}


### PR DESCRIPTION
## Summary
- add a helper component that enables Geoman opt-in mode so layers aren't editable by default
- use this component inside `MapContainer`

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6875713ff8ac83209de52c36fe854d9b