### PR TITLE
Limit vertex editing to Edit Layers mode

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -60,6 +60,10 @@ const ManagedGeoJsonLayer = ({
   useEffect(() => {
     if (!geoJsonRef.current) return;
     geoJsonRef.current.eachLayer((layer: any) => {
+      if (isEditingLayer) {
+        // Re-init layer in case Geoman opt-in disabled it
+        (L as any).PM?.reInitLayer?.(layer);
+      }
       const idx = data.features.indexOf(layer.feature as any);
       if (isEditingLayer && editingFeatureIndex === idx) {
         layer.pm.enable({
@@ -379,6 +383,12 @@ const MapComponent: React.FC<MapComponentProps> = ({
   onDiscardEdits,
 }) => {
   const layerRefs = useRef<Record<string, L.GeoJSON | null>>({});
+
+  // Require explicit opt-in for Geoman editing so layers aren't editable
+  // unless the Edit Layers mode is active.
+  useEffect(() => {
+    (L as any).PM?.setOptIn?.(true);
+  }, []);
 
   const handleSaveClick = () => {
     if (editingTarget?.layerId) {


### PR DESCRIPTION
## Summary
- restrict geoman editing to run only when Edit Layers mode is active
- re-initialize layers when editing is enabled

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875713ff8ac83209de52c36fe854d9b