### PR TITLE
Disable unwanted polygon editing

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -3,6 +3,9 @@ import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } f
 import L from 'leaflet';
 import 'leaflet-draw';
 import '@geoman-io/leaflet-geoman-free';
+
+// Require explicit activation of Leaflet-Geoman on layers
+L.PM.setOptIn(true);
 import { area as turfArea, intersect as turfIntersect } from '@turf/turf';
 import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';


### PR DESCRIPTION
## Summary
- enforce Geoman opt-in mode to prevent accidental polygon editing

## Testing
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6875713ff8ac83209de52c36fe854d9b