### PR TITLE
Add official layer names for uploaded zips

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -34,8 +34,18 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
 
     try {
       let buffer = await file.arrayBuffer();
+      const baseName = file.name.replace(/\.zip$/i, '');
       let displayName = file.name;
-      const isWssFile = file.name.toLowerCase().startsWith('wss_aoi_');
+      const lowerBase = baseName.toLowerCase();
+      const isWssFile = lowerBase.startsWith('wss_aoi_');
+
+      if (lowerBase === 'da') {
+        displayName = 'Drainage Areas';
+      } else if (lowerBase === 'landcover') {
+        displayName = 'Land Cover';
+      } else if (lowerBase === 'lod') {
+        displayName = 'LOD';
+      }
 
       // Special handling for Web Soil Survey files
       if (isWssFile) {
@@ -58,7 +68,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
         }
         
         buffer = await newZip.generateAsync({ type: 'arraybuffer' });
-        displayName = `${targetBasename}.shp`;
+        displayName = 'Soil Layer from Web Soil Survey';
       }
 
       let geojson = await shp.parseZip(buffer) as FeatureCollection;


### PR DESCRIPTION
## Summary
- assign human-friendly names to uploaded layers
- set WSS layers' name to "Soil Layer from Web Soil Survey"
- handle official names for Drainage Areas, Land Cover and LOD zips

## Testing
- `npm install`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_6875756fce548320823c65a795de25b1