### PR TITLE
Improve layer name detection

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -34,8 +34,20 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
 
     try {
       let buffer = await file.arrayBuffer();
+      const lowerName = file.name.toLowerCase();
       let displayName = file.name;
-      const isWssFile = file.name.toLowerCase().startsWith('wss_aoi_');
+      const isWssFile = lowerName.startsWith('wss_aoi_');
+
+      // Determine a user-friendly layer name based on known archives
+      if (isWssFile) {
+        displayName = 'Soil Layer from Web Soil Survey';
+      } else if (lowerName === 'da.zip') {
+        displayName = 'Drainage Areas';
+      } else if (lowerName === 'landcover.zip') {
+        displayName = 'Land Cover';
+      } else if (lowerName === 'lod.zip') {
+        displayName = 'LOD';
+      }
 
       // Special handling for Web Soil Survey files
       if (isWssFile) {
@@ -58,7 +70,6 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
         }
         
         buffer = await newZip.generateAsync({ type: 'arraybuffer' });
-        displayName = `${targetBasename}.shp`;
       }
 
       let geojson = await shp.parseZip(buffer) as FeatureCollection;


### PR DESCRIPTION
## Summary
- detect more shapefile archive names when uploading layers
- name recognized files `Soil Layer from Web Soil Survey`, `Drainage Areas`, `Land Cover`, or `LOD`

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6875756fce548320823c65a795de25b1