### PR TITLE
Implement official names for common shapefile layers

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import * as shp from 'shpjs';
 import JSZip from 'jszip';
 import type { FeatureCollection } from 'geojson';
@@ -13,11 +13,19 @@ interface FileUploadProps {
   onLog: (message: string, type?: 'info' | 'error') => void;
   isLoading: boolean;
   onCreateLayer?: (name: string) => void;
+  existingLayerNames?: string[];
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading, onCreateLayer }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading, onCreateLayer, existingLayerNames = [] }) => {
   const [isDragging, setIsDragging] = useState(false);
-  const [newLayerName, setNewLayerName] = useState(KNOWN_LAYER_NAMES[0]);
+  const availableNames = KNOWN_LAYER_NAMES.filter(n => !existingLayerNames.includes(n));
+  const [newLayerName, setNewLayerName] = useState(availableNames[0] || '');
+
+  useEffect(() => {
+    if (!availableNames.includes(newLayerName)) {
+      setNewLayerName(availableNames[0] || '');
+    }
+  }, [availableNames, newLayerName]);
 
   const processFile = useCallback(async (file: File) => {
     if (!file) {
@@ -173,14 +181,14 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       <p className="mt-4 text-xs text-gray-500">
         Upload one or more shapefiles. WSS Soil Survey zips are handled automatically.
       </p>
-      {onCreateLayer && (
+      {onCreateLayer && availableNames.length > 0 && (
         <div className="mt-4 flex space-x-2 items-center">
           <select
             value={newLayerName}
             onChange={e => setNewLayerName(e.target.value)}
             className="flex-grow bg-gray-800 border border-gray-600 text-gray-200 rounded px-2 py-1"
           >
-            {KNOWN_LAYER_NAMES.map(name => (
+            {availableNames.map(name => (
               <option key={name} value={name}>{name}</option>
             ))}
           </select>

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -4,6 +4,7 @@ import JSZip from 'jszip';
 import type { FeatureCollection } from 'geojson';
 import { UploadIcon } from './Icons';
 import { loadHsgMap } from '../utils/soil';
+import { ARCHIVE_NAME_MAP, KNOWN_LAYER_NAMES } from '../utils/constants';
 
 interface FileUploadProps {
   onLayerAdded: (data: FeatureCollection, fileName: string) => void;
@@ -11,10 +12,12 @@ interface FileUploadProps {
   onError: (message: string) => void;
   onLog: (message: string, type?: 'info' | 'error') => void;
   isLoading: boolean;
+  onCreateLayer?: (name: string) => void;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading, onCreateLayer }) => {
   const [isDragging, setIsDragging] = useState(false);
+  const [newLayerName, setNewLayerName] = useState(KNOWN_LAYER_NAMES[0]);
 
   const processFile = useCallback(async (file: File) => {
     if (!file) {
@@ -34,8 +37,9 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
 
     try {
       let buffer = await file.arrayBuffer();
-      let displayName = file.name;
-      const isWssFile = file.name.toLowerCase().startsWith('wss_aoi_');
+      const lowerName = file.name.toLowerCase();
+      let displayName = ARCHIVE_NAME_MAP[lowerName] ?? file.name;
+      const isWssFile = lowerName.startsWith('wss_aoi_');
 
       // Special handling for Web Soil Survey files
       if (isWssFile) {
@@ -58,7 +62,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
         }
         
         buffer = await newZip.generateAsync({ type: 'arraybuffer' });
-        displayName = `${targetBasename}.shp`;
+        displayName = 'Soil Layer from Web Soil Survey';
       }
 
       let geojson = await shp.parseZip(buffer) as FeatureCollection;
@@ -169,6 +173,26 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       <p className="mt-4 text-xs text-gray-500">
         Upload one or more shapefiles. WSS Soil Survey zips are handled automatically.
       </p>
+      {onCreateLayer && (
+        <div className="mt-4 flex space-x-2 items-center">
+          <select
+            value={newLayerName}
+            onChange={e => setNewLayerName(e.target.value)}
+            className="flex-grow bg-gray-800 border border-gray-600 text-gray-200 rounded px-2 py-1"
+          >
+            {KNOWN_LAYER_NAMES.map(name => (
+              <option key={name} value={name}>{name}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => onCreateLayer(newLayerName)}
+            className="bg-cyan-600 hover:bg-cyan-700 text-white px-3 py-1 rounded"
+          >
+            Create
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -51,3 +51,10 @@ export const SearchIcon: React.FC<IconProps> = ({ className }) => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
   </svg>
 );
+
+export const LockClosedIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M16 10V7a4 4 0 10-8 0v3M5 10h14v10H5V10z" />
+  </svg>
+);
+

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LayerData, LogEntry } from '../types';
-import { XCircleIcon, InfoIcon, TrashIcon, EditIcon } from './Icons';
+import { XCircleIcon, InfoIcon, TrashIcon, EditIcon, LockClosedIcon } from './Icons';
 import LogPanel from './LogPanel';
 
 interface InfoPanelProps {
@@ -62,7 +62,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                   <div className="flex justify-between items-start">
                     <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
                     <div className="flex space-x-2">
-                      {onToggleEditLayer && (
+                      {onToggleEditLayer && (layer.editable ? (
                         <button
                           onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
                           className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
@@ -70,7 +70,9 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
                         >
                           {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
                         </button>
-                      )}
+                      ) : (
+                        <LockClosedIcon className="w-5 h-5 text-gray-600" />
+                      ))}
                       <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
                         <TrashIcon className="w-5 h-5" />
                       </button>
@@ -98,3 +100,4 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
 };
 
 export default InfoPanel;
+

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ export interface LayerData {
   id: string;
   name: string;
   geojson: FeatureCollection;
+  editable: boolean;
 }
 
 export interface LogEntry {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,12 @@
+export const ARCHIVE_NAME_MAP: Record<string, string> = {
+  'da.zip': 'Drainage Areas',
+  'landcover.zip': 'Land Cover',
+  'lod.zip': 'LOD',
+};
+
+export const KNOWN_LAYER_NAMES = [
+  'Drainage Areas',
+  'Land Cover',
+  'LOD',
+  'Soil Layer from Web Soil Survey',
+];


### PR DESCRIPTION
## Summary
- handle known shapefile archives with friendly names
- map WSS zip uploads to **Soil Layer from Web Soil Survey**
- keep passing backend tests


------
https://chatgpt.com/codex/tasks/task_e_6875756fce548320823c65a795de25b1