### PR TITLE
Add dropdown naming for Drainage Areas

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,11 @@ import InstructionsPage from './components/InstructionsPage';
 import { KNOWN_LAYER_NAMES } from './utils/constants';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
+type UpdateDaNameFn = (
+  layerId: string,
+  featureIndex: number,
+  name: string
+) => void;
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -122,6 +127,18 @@ const App: React.FC = () => {
     addLog(`Set HSG for feature ${featureIndex} in ${layerId} to ${hsg}`);
   }, [addLog]);
 
+  const handleUpdateFeatureDaName = useCallback<UpdateDaNameFn>((layerId, featureIndex, name) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), DA_NAME: name };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set DA_NAME for feature ${featureIndex} in ${layerId} to ${name}`);
+  }, [addLog]);
+
   const handleDiscardEditing = useCallback(() => {
     if (!editingTarget.layerId) return;
     const id = editingTarget.layerId;
@@ -198,6 +215,7 @@ const App: React.FC = () => {
             <MapComponent
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
+              onUpdateFeatureDaName={handleUpdateFeatureDaName}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}
               onSelectFeatureForEditing={handleSelectFeatureForEditing}

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -101,6 +101,14 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       }
       // --- END OF ENRICHMENT LOGIC ---
 
+      if (displayName === 'Drainage Areas') {
+        geojson.features = geojson.features.map(feature => {
+          const props = { ...(feature.properties || {}) } as Record<string, any>;
+          if (!('DA_NAME' in props)) props.DA_NAME = '';
+          return { ...feature, properties: props } as any;
+        });
+      }
+
       onLayerAdded(geojson, displayName);
       onLog(`Loaded ${displayName}`);
     } catch (e) {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -10,3 +10,7 @@ export const KNOWN_LAYER_NAMES = [
   'LOD',
   'Soil Layer from Web Soil Survey',
 ];
+
+export const DRAINAGE_AREA_NAME_OPTIONS = Array.from({ length: 26 }, (_, i) =>
+  `DA-${String.fromCharCode(65 + i)}`
+);


### PR DESCRIPTION
## Summary
- add constant list of DA names
- default Drainage Areas features to empty `DA_NAME`
- store Drainage Area name edits
- display dropdown inside polygon to set `DA_NAME`

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68810d7642d08320b57080f5b6ec1656