### PR TITLE
Refine CN data format

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { KNOWN_LAYER_NAMES } from './utils/constants';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
+type UpdateLandCoverFn = (layerId: string, featureIndex: number, lc: string) => void;
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -61,6 +62,16 @@ const App: React.FC = () => {
         features: geojson.features.map(f => ({
           ...f,
           properties: { ...(f.properties || {}), DA_NAME: f.properties?.DA_NAME ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+
+    if (name === 'Land Cover') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), LAND_COVER: f.properties?.LAND_COVER ?? '' }
         }))
       } as FeatureCollection;
     }
@@ -145,6 +156,18 @@ const App: React.FC = () => {
     addLog(`Set Drainage Area name for feature ${featureIndex} in ${layerId} to ${nameVal}`);
   }, [addLog]);
 
+  const handleUpdateFeatureLandCover = useCallback<UpdateLandCoverFn>((layerId, featureIndex, lcVal) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), LAND_COVER: lcVal };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set land cover for feature ${featureIndex} in ${layerId} to ${lcVal}`);
+  }, [addLog]);
+
   const handleDiscardEditing = useCallback(() => {
     if (!editingTarget.layerId) return;
     const id = editingTarget.layerId;
@@ -221,6 +244,7 @@ const App: React.FC = () => {
             <MapComponent
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
+              onUpdateFeatureLandCover={handleUpdateFeatureLandCover}
               onUpdateFeatureDaName={handleUpdateFeatureDaName}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,27 @@
+export interface CurveNumberEntry {
+  Description: string;
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+}
+
+export async function loadCnValues(): Promise<CurveNumberEntry[] | null> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return (await res.json()) as CurveNumberEntry[];
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return null;
+}
+
+export function getLandCoverOptions(data: CurveNumberEntry[]): string[] {
+  return Array.from(new Set(data.map(d => d.Description)));
+}


### PR DESCRIPTION
## Summary
- keep TR-55 values as an array of records
- expose helper to list land cover options
- load land cover options using the helper
- document CN endpoint without internal details

## Testing
- `npm install --silent`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68812772376c83209e2552b9e2002d23