### PR TITLE
Add editable defaults for new polygons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { KNOWN_LAYER_NAMES } from './utils/constants';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
+type UpdateLandCoverFn = (layerId: string, featureIndex: number, lc: string) => void;
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -61,6 +62,16 @@ const App: React.FC = () => {
         features: geojson.features.map(f => ({
           ...f,
           properties: { ...(f.properties || {}), DA_NAME: f.properties?.DA_NAME ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+
+    if (name === 'Land Cover') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), LAND_COVER: f.properties?.LAND_COVER ?? '' }
         }))
       } as FeatureCollection;
     }
@@ -145,6 +156,18 @@ const App: React.FC = () => {
     addLog(`Set Drainage Area name for feature ${featureIndex} in ${layerId} to ${nameVal}`);
   }, [addLog]);
 
+  const handleUpdateFeatureLandCover = useCallback<UpdateLandCoverFn>((layerId, featureIndex, lcVal) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), LAND_COVER: lcVal };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set land cover for feature ${featureIndex} in ${layerId} to ${lcVal}`);
+  }, [addLog]);
+
   const handleDiscardEditing = useCallback(() => {
     if (!editingTarget.layerId) return;
     const id = editingTarget.layerId;
@@ -221,6 +244,7 @@ const App: React.FC = () => {
             <MapComponent
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
+              onUpdateFeatureLandCover={handleUpdateFeatureLandCover}
               onUpdateFeatureDaName={handleUpdateFeatureDaName}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ analysis:
 
 * `GET /api/cn-values` returns the contents of `public/data/SCS_CN_VALUES.json`.
 
+  The JSON maps land cover descriptions to arrays of Curve Number records, each
+  providing values for hydrologic soil groups A–D as listed in the TR‐55 tables.
+  Duplicated descriptions therefore hold multiple CN sets to cover different
+  conditions.
+
 This allows the frontend to fetch the table of CN values based on soil group.
 
 These routes are ready for future integration with the frontend.

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet-draw';
@@ -8,12 +8,14 @@ import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
+import { loadCnValues } from '../utils/cn';
 
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
 interface MapComponentProps {
   layers: LayerData[];
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, lc: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
   zoomToLayer?: { id: string; ts: number } | null;
   editingTarget?: { layerId: string | null; featureIndex: number | null };
@@ -30,6 +32,7 @@ const ManagedGeoJsonLayer = ({
   data,
   isLastAdded,
   onUpdateFeatureHsg,
+  onUpdateFeatureLandCover,
   onUpdateFeatureDaName,
   layerName,
   isEditingLayer,
@@ -42,6 +45,7 @@ const ManagedGeoJsonLayer = ({
   data: LayerData['geojson'];
   isLastAdded: boolean;
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, lc: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
   layerName: string;
   isEditingLayer: boolean;
@@ -126,7 +130,7 @@ const ManagedGeoJsonLayer = ({
 
       // Render all properties except HSG
       Object.entries(feature.properties).forEach(([k, v]) => {
-        if (k === 'HSG') return;
+        if (k === 'HSG' || k === 'LAND_COVER') return;
         const row = L.DomUtil.create('div', '', propsDiv);
         row.innerHTML = `<b>${k}:</b> ${v}`;
       });
@@ -170,6 +174,35 @@ const ManagedGeoJsonLayer = ({
           const idx = data.features.indexOf(feature);
           onUpdateFeatureHsg(id, idx, newVal);
           feature.properties!.HSG = newVal;
+        });
+      }
+
+      if (layerName === 'Land Cover') {
+        const lcRow = L.DomUtil.create('div', '', propsDiv);
+        const label = L.DomUtil.create('b', '', lcRow);
+        label.textContent = 'Land Cover: ';
+        const select = L.DomUtil.create('select', '', lcRow) as HTMLSelectElement;
+        select.title = 'Seleccionar land cover';
+        select.style.marginLeft = '4px';
+        select.style.border = '2px solid #fb923c';
+        select.style.backgroundColor = '#ffedd5';
+        select.style.fontWeight = 'bold';
+        const blank = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+        blank.value = '';
+        blank.textContent = '--';
+        cnOptions.forEach(val => {
+          const opt = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+          opt.value = val;
+          opt.textContent = val;
+          if (feature.properties?.LAND_COVER === val) opt.selected = true;
+        });
+        if (!feature.properties?.LAND_COVER) blank.selected = true;
+        select.addEventListener('change', (e) => {
+          const newVal = (e.target as HTMLSelectElement).value;
+          const idx = data.features.indexOf(feature);
+          onUpdateFeatureLandCover(id, idx, newVal);
+          if (!feature.properties) feature.properties = {} as any;
+          (feature.properties as any).LAND_COVER = newVal;
         });
       }
 
@@ -269,10 +302,12 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
 const GeomanControls = ({
   active,
   layer,
+  layerName,
   onChange,
 }: {
   active: boolean;
   layer: L.GeoJSON | null;
+  layerName?: string;
   onChange?: (geojson: LayerData['geojson']) => void;
 }) => {
   const map = useMap();
@@ -380,6 +415,15 @@ const GeomanControls = ({
 
     const handleCreate = (e: any) => {
       checkOverlap(e.layer);
+      const feat = e.layer.toGeoJSON() as any;
+      if (layerName === 'Land Cover') {
+        feat.properties = { ...(feat.properties || {}), LAND_COVER: '' };
+      } else if (layerName === 'Soil Layer from Web Soil Survey') {
+        feat.properties = { ...(feat.properties || {}), HSG: '' };
+      } else if (layerName === 'Drainage Areas') {
+        feat.properties = { ...(feat.properties || {}), DA_NAME: '' };
+      }
+      e.layer.feature = feat;
       onChange && onChange(layer.toGeoJSON() as LayerData['geojson']);
     };
     const handleRemove = () => {
@@ -411,6 +455,7 @@ const GeomanControls = ({
 const MapComponent: React.FC<MapComponentProps> = ({
   layers,
   onUpdateFeatureHsg,
+  onUpdateFeatureLandCover,
   onUpdateFeatureDaName,
   zoomToLayer,
   editingTarget,
@@ -420,6 +465,13 @@ const MapComponent: React.FC<MapComponentProps> = ({
   onDiscardEdits,
 }) => {
   const layerRefs = useRef<Record<string, L.GeoJSON | null>>({});
+  const [cnOptions, setCnOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    loadCnValues().then(data => {
+      if (data) setCnOptions(Object.keys(data));
+    }).catch(err => console.warn('Failed to load CN values', err));
+  }, []);
 
   const handleSaveClick = () => {
     if (editingTarget?.layerId) {
@@ -434,15 +486,22 @@ const MapComponent: React.FC<MapComponentProps> = ({
   return (
     <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={true} className="h-full w-full relative">
       <ZoomToLayerHandler layers={layers} target={zoomToLayer ?? null} />
-      <GeomanControls
-        active={!!editingTarget?.layerId}
-        layer={editingTarget?.layerId ? layerRefs.current[editingTarget.layerId] : null}
-        onChange={(geo) => {
-          if (editingTarget?.layerId && onUpdateLayerGeojson) {
-            onUpdateLayerGeojson(editingTarget.layerId, geo);
-          }
-        }}
-      />
+      {(() => {
+        const editingLayer = layers.find(l => l.id === editingTarget?.layerId);
+        const editingName = editingLayer?.name;
+        return (
+          <GeomanControls
+            active={!!editingTarget?.layerId}
+            layer={editingTarget?.layerId ? layerRefs.current[editingTarget.layerId] : null}
+            layerName={editingName}
+            onChange={(geo) => {
+              if (editingTarget?.layerId && onUpdateLayerGeojson) {
+                onUpdateLayerGeojson(editingTarget.layerId, geo);
+              }
+            }}
+          />
+        );
+      })()}
       <div className="absolute top-2 left-2 z-[1000] w-64">
         <AddressSearch />
       </div>
@@ -521,6 +580,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
                 data={layer.geojson}
                 isLastAdded={index === layers.length - 1}
                 onUpdateFeatureHsg={onUpdateFeatureHsg}
+                onUpdateFeatureLandCover={onUpdateFeatureLandCover}
                 onUpdateFeatureDaName={onUpdateFeatureDaName}
                 layerName={layer.name}
                 isEditingLayer={editingTarget?.layerId === layer.id}

--- a/public/data/SCS_CN_VALUES.json
+++ b/public/data/SCS_CN_VALUES.json
@@ -1,520 +1,530 @@
-[
-  {
-    "Description": "Open space (lawns, parks etc.)",
-    "A": 68,
-    "B": 79,
-    "C": 86,
-    "D": 89
-  },
-  {
-    "Description": "grass cover > 50%",
-    "A": 49,
-    "B": 69,
-    "C": 79,
-    "D": 84
-  },
-  {
-    "Description": "grass cover 50% to 75%",
-    "A": 39,
-    "B": 61,
-    "C": 74,
-    "D": 80
-  },
-  {
-    "Description": "Classified as Pervious",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Paved parking lots, driveways",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Unconnected Impervious",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Roofs",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Unconnected Impervious",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Paved; curbs and storm sewers",
-    "A": 98,
-    "B": 98,
-    "C": 98,
-    "D": 98
-  },
-  {
-    "Description": "Paved; open ditches (w/ROW)",
-    "A": 83,
-    "B": 89,
-    "C": 92,
-    "D": 93
-  },
-  {
-    "Description": "Gravel (w/o right-of-way)",
-    "A": 96,
-    "B": 96,
-    "C": 96,
-    "D": 96
-  },
-  {
-    "Description": "Gravel (w/ right-of-way)",
-    "A": 76,
-    "B": 85,
-    "C": 89,
-    "D": 91
-  },
-  {
-    "Description": "Dirt (w/ right-of-way)",
-    "A": 72,
-    "B": 82,
-    "C": 87,
-    "D": 89
-  },
-  {
-    "Description": "Commercial & business",
-    "A": 89,
-    "B": 92,
-    "C": 94,
-    "D": 95
-  },
-  {
-    "Description": "Industrial",
-    "A": 81,
-    "B": 88,
-    "C": 91,
-    "D": 93
-  },
-  {
-    "Description": "1/8 acre (town houses)",
-    "A": 77,
-    "B": 85,
-    "C": 90,
-    "D": 92
-  },
-  {
-    "Description": "1/4 acre",
-    "A": 61,
-    "B": 75,
-    "C": 83,
-    "D": 87
-  },
-  {
-    "Description": "1/3 acre",
-    "A": 57,
-    "B": 72,
-    "C": 81,
-    "D": 86
-  },
-  {
-    "Description": "1/2 acre",
-    "A": 54,
-    "B": 70,
-    "C": 80,
-    "D": 85
-  },
-  {
-    "Description": "1 acre",
-    "A": 51,
-    "B": 68,
-    "C": 79,
-    "D": 84
-  },
-  {
-    "Description": "2 acre",
-    "A": 46,
-    "B": 65,
-    "C": 77,
-    "D": 82
-  },
-  {
-    "Description": "Natural desert (pervious areas only)",
-    "A": 63,
-    "B": 77,
-    "C": 85,
-    "D": 88
-  },
-  {
-    "Description": "Artifical desert landscaping",
-    "A": 96,
-    "B": 96,
-    "C": 96,
-    "D": 96
-  },
-  {
-    "Description": "Newly graded area (pervious only)",
-    "A": 77,
-    "B": 86,
-    "C": 91,
-    "D": 94
-  },
-  {
-    "Description": "Bare soil",
-    "A": 77,
-    "B": 86,
-    "C": 91,
-    "D": 94
-  },
-  {
-    "Description": "Crop residue (CR)",
-    "A": 76,
-    "B": 85,
-    "C": 90,
-    "D": 93
-  },
-  {
-    "Description": "Crop residue (CR)",
-    "A": 74,
-    "B": 83,
-    "C": 88,
-    "D": 90
-  },
-  {
-    "Description": "Straight row (SR)",
-    "A": 72,
-    "B": 81,
-    "C": 88,
-    "D": 91
-  },
-  {
-    "Description": "Straight row (SR)",
-    "A": 67,
-    "B": 78,
-    "C": 85,
-    "D": 89
-  },
-  {
-    "Description": "SR + Crop residue",
-    "A": 71,
-    "B": 80,
-    "C": 87,
-    "D": 90
-  },
-  {
-    "Description": "SR + Crop residue",
-    "A": 64,
-    "B": 75,
-    "C": 82,
-    "D": 86
-  },
-  {
-    "Description": "Contoured (C)",
-    "A": 70,
-    "B": 79,
-    "C": 84,
-    "D": 88
-  },
-  {
-    "Description": "Contoured (C)",
-    "A": 65,
-    "B": 75,
-    "C": 82,
-    "D": 86
-  },
-  {
-    "Description": "C + Crop residue",
-    "A": 69,
-    "B": 78,
-    "C": 83,
-    "D": 87
-  },
-  {
-    "Description": "C + Crop residue",
-    "A": 64,
-    "B": 74,
-    "C": 81,
-    "D": 85
-  },
-  {
-    "Description": "Contoured & terraced (C&T)",
-    "A": 66,
-    "B": 74,
-    "C": 80,
-    "D": 82
-  },
-  {
-    "Description": "Contoured & terraced (C&T)",
-    "A": 62,
-    "B": 71,
-    "C": 78,
-    "D": 81
-  },
-  {
-    "Description": "C&T + Crop residue",
-    "A": 65,
-    "B": 73,
-    "C": 79,
-    "D": 81
-  },
-  {
-    "Description": "C&T + Crop residue",
-    "A": 61,
-    "B": 70,
-    "C": 77,
-    "D": 80
-  },
-  {
-    "Description": "Straight row (SR)",
-    "A": 65,
-    "B": 76,
-    "C": 84,
-    "D": 88
-  },
-  {
-    "Description": "Straight row (SR)",
-    "A": 63,
-    "B": 75,
-    "C": 83,
-    "D": 87
-  },
-  {
-    "Description": "SR + Crop residue",
-    "A": 64,
-    "B": 75,
-    "C": 83,
-    "D": 86
-  },
-  {
-    "Description": "SR + Crop residue",
-    "A": 60,
-    "B": 72,
-    "C": 80,
-    "D": 84
-  },
-  {
-    "Description": "Contoured (C)",
-    "A": 63,
-    "B": 74,
-    "C": 82,
-    "D": 85
-  },
-  {
-    "Description": "Contoured (C)",
-    "A": 61,
-    "B": 73,
-    "C": 81,
-    "D": 84
-  },
-  {
-    "Description": "C + Crop residue",
-    "A": 62,
-    "B": 73,
-    "C": 81,
-    "D": 84
-  },
-  {
-    "Description": "C + Crop residue",
-    "A": 60,
-    "B": 72,
-    "C": 80,
-    "D": 83
-  },
-  {
-    "Description": "Contoured & terraced (C&T)",
-    "A": 61,
-    "B": 72,
-    "C": 79,
-    "D": 82
-  },
-  {
-    "Description": "Contoured & terraced (C&T)",
-    "A": 59,
-    "B": 70,
-    "C": 78,
-    "D": 81
-  },
-  {
-    "Description": "C&T + Crop residue",
-    "A": 60,
-    "B": 71,
-    "C": 78,
-    "D": 81
-  },
-  {
-    "Description": "C&T + Crop residue",
-    "A": 58,
-    "B": 69,
-    "C": 77,
-    "D": 80
-  },
-  {
-    "Description": "Straight row",
-    "A": 66,
-    "B": 77,
-    "C": 85,
-    "D": 89
-  },
-  {
-    "Description": "Straight row",
-    "A": 58,
-    "B": 72,
-    "C": 81,
-    "D": 85
-  },
-  {
-    "Description": "Contoured",
-    "A": 64,
-    "B": 75,
-    "C": 83,
-    "D": 85
-  },
-  {
-    "Description": "Contoured",
-    "A": 55,
-    "B": 69,
-    "C": 78,
-    "D": 83
-  },
-  {
-    "Description": "Cont & terraced",
-    "A": 63,
-    "B": 73,
-    "C": 80,
-    "D": 83
-  },
-  {
-    "Description": "Cont & terraced",
-    "A": 51,
-    "B": 67,
-    "C": 76,
-    "D": 80
-  },
-  {
-    "Description": "Pasture, grassland or range",
-    "A": 68,
-    "B": 79,
-    "C": 86,
-    "D": 89
-  },
-  {
-    "Description": "Unknown",
-    "A": 49,
-    "B": 69,
-    "C": 79,
-    "D": 84
-  },
-  {
-    "Description": "Unknown",
-    "A": 39,
-    "B": 61,
-    "C": 74,
-    "D": 80
-  },
-  {
-    "Description": "Meadow, cont. grass, non-grazed",
-    "A": 30,
-    "B": 58,
-    "C": 71,
-    "D": 78
-  },
-  {
-    "Description": "Brush, brush/weed/grass mix",
-    "A": 48,
-    "B": 67,
-    "C": 77,
-    "D": 83
-  },
-  {
-    "Description": "Unknown",
-    "A": 35,
-    "B": 56,
-    "C": 70,
-    "D": 77
-  },
-  {
-    "Description": "Unknown",
-    "A": 30,
-    "B": 48,
-    "C": 65,
-    "D": 73
-  },
-  {
-    "Description": "Woods/grass combination",
-    "A": 57,
-    "B": 73,
-    "C": 82,
-    "D": 86
-  },
-  {
-    "Description": "Unknown",
-    "A": 43,
-    "B": 65,
-    "C": 76,
-    "D": 82
-  },
-  {
-    "Description": "Unknown",
-    "A": 32,
-    "B": 58,
-    "C": 72,
-    "D": 79
-  },
-  {
-    "Description": "Woods",
-    "A": 45,
-    "B": 66,
-    "C": 77,
-    "D": 83
-  },
-  {
-    "Description": "Unknown",
-    "A": 36,
-    "B": 60,
-    "C": 73,
-    "D": 79
-  },
-  {
-    "Description": "Unknown",
-    "A": 30,
-    "B": 55,
-    "C": 70,
-    "D": 77
-  },
-  {
-    "Description": "Farmsteads",
-    "A": 59,
-    "B": 74,
-    "C": 82,
-    "D": 86
-  },
-  {
-    "Description": "Desert shrub",
-    "A": 63,
-    "B": 77,
-    "C": 85,
-    "D": 88
-  },
-  {
-    "Description": "Unknown",
-    "A": 55,
-    "B": 72,
-    "C": 81,
-    "D": 86
-  },
-  {
-    "Description": "Unknown",
-    "A": 49,
-    "B": 68,
-    "C": 79,
-    "D": 84
-  }
-]
+{
+  "Open space (lawns, parks etc.)": [
+    {
+      "A": 68,
+      "B": 79,
+      "C": 86,
+      "D": 89
+    }
+  ],
+  "grass cover > 50%": [
+    {
+      "A": 49,
+      "B": 69,
+      "C": 79,
+      "D": 84
+    }
+  ],
+  "grass cover 50% to 75%": [
+    {
+      "A": 39,
+      "B": 61,
+      "C": 74,
+      "D": 80
+    }
+  ],
+  "Classified as Pervious": [
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    }
+  ],
+  "Paved parking lots, driveways": [
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    }
+  ],
+  "Unconnected Impervious": [
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    },
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    }
+  ],
+  "Roofs": [
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    }
+  ],
+  "Paved; curbs and storm sewers": [
+    {
+      "A": 98,
+      "B": 98,
+      "C": 98,
+      "D": 98
+    }
+  ],
+  "Paved; open ditches (w/ROW)": [
+    {
+      "A": 83,
+      "B": 89,
+      "C": 92,
+      "D": 93
+    }
+  ],
+  "Gravel (w/o right-of-way)": [
+    {
+      "A": 96,
+      "B": 96,
+      "C": 96,
+      "D": 96
+    }
+  ],
+  "Gravel (w/ right-of-way)": [
+    {
+      "A": 76,
+      "B": 85,
+      "C": 89,
+      "D": 91
+    }
+  ],
+  "Dirt (w/ right-of-way)": [
+    {
+      "A": 72,
+      "B": 82,
+      "C": 87,
+      "D": 89
+    }
+  ],
+  "Commercial & business": [
+    {
+      "A": 89,
+      "B": 92,
+      "C": 94,
+      "D": 95
+    }
+  ],
+  "Industrial": [
+    {
+      "A": 81,
+      "B": 88,
+      "C": 91,
+      "D": 93
+    }
+  ],
+  "1/8 acre (town houses)": [
+    {
+      "A": 77,
+      "B": 85,
+      "C": 90,
+      "D": 92
+    }
+  ],
+  "1/4 acre": [
+    {
+      "A": 61,
+      "B": 75,
+      "C": 83,
+      "D": 87
+    }
+  ],
+  "1/3 acre": [
+    {
+      "A": 57,
+      "B": 72,
+      "C": 81,
+      "D": 86
+    }
+  ],
+  "1/2 acre": [
+    {
+      "A": 54,
+      "B": 70,
+      "C": 80,
+      "D": 85
+    }
+  ],
+  "1 acre": [
+    {
+      "A": 51,
+      "B": 68,
+      "C": 79,
+      "D": 84
+    }
+  ],
+  "2 acre": [
+    {
+      "A": 46,
+      "B": 65,
+      "C": 77,
+      "D": 82
+    }
+  ],
+  "Natural desert (pervious areas only)": [
+    {
+      "A": 63,
+      "B": 77,
+      "C": 85,
+      "D": 88
+    }
+  ],
+  "Artifical desert landscaping": [
+    {
+      "A": 96,
+      "B": 96,
+      "C": 96,
+      "D": 96
+    }
+  ],
+  "Newly graded area (pervious only)": [
+    {
+      "A": 77,
+      "B": 86,
+      "C": 91,
+      "D": 94
+    }
+  ],
+  "Bare soil": [
+    {
+      "A": 77,
+      "B": 86,
+      "C": 91,
+      "D": 94
+    }
+  ],
+  "Crop residue (CR)": [
+    {
+      "A": 76,
+      "B": 85,
+      "C": 90,
+      "D": 93
+    },
+    {
+      "A": 74,
+      "B": 83,
+      "C": 88,
+      "D": 90
+    }
+  ],
+  "Straight row (SR)": [
+    {
+      "A": 72,
+      "B": 81,
+      "C": 88,
+      "D": 91
+    },
+    {
+      "A": 67,
+      "B": 78,
+      "C": 85,
+      "D": 89
+    },
+    {
+      "A": 65,
+      "B": 76,
+      "C": 84,
+      "D": 88
+    },
+    {
+      "A": 63,
+      "B": 75,
+      "C": 83,
+      "D": 87
+    }
+  ],
+  "SR + Crop residue": [
+    {
+      "A": 71,
+      "B": 80,
+      "C": 87,
+      "D": 90
+    },
+    {
+      "A": 64,
+      "B": 75,
+      "C": 82,
+      "D": 86
+    },
+    {
+      "A": 64,
+      "B": 75,
+      "C": 83,
+      "D": 86
+    },
+    {
+      "A": 60,
+      "B": 72,
+      "C": 80,
+      "D": 84
+    }
+  ],
+  "Contoured (C)": [
+    {
+      "A": 70,
+      "B": 79,
+      "C": 84,
+      "D": 88
+    },
+    {
+      "A": 65,
+      "B": 75,
+      "C": 82,
+      "D": 86
+    },
+    {
+      "A": 63,
+      "B": 74,
+      "C": 82,
+      "D": 85
+    },
+    {
+      "A": 61,
+      "B": 73,
+      "C": 81,
+      "D": 84
+    }
+  ],
+  "C + Crop residue": [
+    {
+      "A": 69,
+      "B": 78,
+      "C": 83,
+      "D": 87
+    },
+    {
+      "A": 64,
+      "B": 74,
+      "C": 81,
+      "D": 85
+    },
+    {
+      "A": 62,
+      "B": 73,
+      "C": 81,
+      "D": 84
+    },
+    {
+      "A": 60,
+      "B": 72,
+      "C": 80,
+      "D": 83
+    }
+  ],
+  "Contoured & terraced (C&T)": [
+    {
+      "A": 66,
+      "B": 74,
+      "C": 80,
+      "D": 82
+    },
+    {
+      "A": 62,
+      "B": 71,
+      "C": 78,
+      "D": 81
+    },
+    {
+      "A": 61,
+      "B": 72,
+      "C": 79,
+      "D": 82
+    },
+    {
+      "A": 59,
+      "B": 70,
+      "C": 78,
+      "D": 81
+    }
+  ],
+  "C&T + Crop residue": [
+    {
+      "A": 65,
+      "B": 73,
+      "C": 79,
+      "D": 81
+    },
+    {
+      "A": 61,
+      "B": 70,
+      "C": 77,
+      "D": 80
+    },
+    {
+      "A": 60,
+      "B": 71,
+      "C": 78,
+      "D": 81
+    },
+    {
+      "A": 58,
+      "B": 69,
+      "C": 77,
+      "D": 80
+    }
+  ],
+  "Straight row": [
+    {
+      "A": 66,
+      "B": 77,
+      "C": 85,
+      "D": 89
+    },
+    {
+      "A": 58,
+      "B": 72,
+      "C": 81,
+      "D": 85
+    }
+  ],
+  "Contoured": [
+    {
+      "A": 64,
+      "B": 75,
+      "C": 83,
+      "D": 85
+    },
+    {
+      "A": 55,
+      "B": 69,
+      "C": 78,
+      "D": 83
+    }
+  ],
+  "Cont & terraced": [
+    {
+      "A": 63,
+      "B": 73,
+      "C": 80,
+      "D": 83
+    },
+    {
+      "A": 51,
+      "B": 67,
+      "C": 76,
+      "D": 80
+    }
+  ],
+  "Pasture, grassland or range": [
+    {
+      "A": 68,
+      "B": 79,
+      "C": 86,
+      "D": 89
+    }
+  ],
+  "Unknown": [
+    {
+      "A": 49,
+      "B": 69,
+      "C": 79,
+      "D": 84
+    },
+    {
+      "A": 39,
+      "B": 61,
+      "C": 74,
+      "D": 80
+    },
+    {
+      "A": 35,
+      "B": 56,
+      "C": 70,
+      "D": 77
+    },
+    {
+      "A": 30,
+      "B": 48,
+      "C": 65,
+      "D": 73
+    },
+    {
+      "A": 43,
+      "B": 65,
+      "C": 76,
+      "D": 82
+    },
+    {
+      "A": 32,
+      "B": 58,
+      "C": 72,
+      "D": 79
+    },
+    {
+      "A": 36,
+      "B": 60,
+      "C": 73,
+      "D": 79
+    },
+    {
+      "A": 30,
+      "B": 55,
+      "C": 70,
+      "D": 77
+    },
+    {
+      "A": 55,
+      "B": 72,
+      "C": 81,
+      "D": 86
+    },
+    {
+      "A": 49,
+      "B": 68,
+      "C": 79,
+      "D": 84
+    }
+  ],
+  "Meadow, cont. grass, non-grazed": [
+    {
+      "A": 30,
+      "B": 58,
+      "C": 71,
+      "D": 78
+    }
+  ],
+  "Brush, brush/weed/grass mix": [
+    {
+      "A": 48,
+      "B": 67,
+      "C": 77,
+      "D": 83
+    }
+  ],
+  "Woods/grass combination": [
+    {
+      "A": 57,
+      "B": 73,
+      "C": 82,
+      "D": 86
+    }
+  ],
+  "Woods": [
+    {
+      "A": 45,
+      "B": 66,
+      "C": 77,
+      "D": 83
+    }
+  ],
+  "Farmsteads": [
+    {
+      "A": 59,
+      "B": 74,
+      "C": 82,
+      "D": 86
+    }
+  ],
+  "Desert shrub": [
+    {
+      "A": 63,
+      "B": 77,
+      "C": 85,
+      "D": 88
+    }
+  ]
+}

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,22 @@
+export interface CurveNumberRecord {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+}
+
+export async function loadCnValues(): Promise<Record<string, CurveNumberRecord[]> | null> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return await res.json();
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- preserve empty land cover/HSG fields when drawing new shapes
- allow Geoman controls to know which layer is being edited

## Testing
- `npm install`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68812772376c83209e2552b9e2002d23