### PR TITLE
Add Land Cover and HSG dropdown editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { KNOWN_LAYER_NAMES } from './utils/constants';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
+type UpdateLcFn = (layerId: string, featureIndex: number, lc: string) => void;
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -61,6 +62,26 @@ const App: React.FC = () => {
         features: geojson.features.map(f => ({
           ...f,
           properties: { ...(f.properties || {}), DA_NAME: f.properties?.DA_NAME ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+
+    if (name === 'Land Cover') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), LAND_COVER: f.properties?.LAND_COVER ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+
+    if (name === 'Soil Layer from Web Soil Survey') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), HSG: f.properties?.HSG ?? '' }
         }))
       } as FeatureCollection;
     }
@@ -145,6 +166,18 @@ const App: React.FC = () => {
     addLog(`Set Drainage Area name for feature ${featureIndex} in ${layerId} to ${nameVal}`);
   }, [addLog]);
 
+  const handleUpdateFeatureLandCover = useCallback<UpdateLcFn>((layerId, featureIndex, lcVal) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), LAND_COVER: lcVal };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set Land Cover for feature ${featureIndex} in ${layerId} to ${lcVal}`);
+  }, [addLog]);
+
   const handleDiscardEditing = useCallback(() => {
     if (!editingTarget.layerId) return;
     const id = editingTarget.layerId;
@@ -222,6 +255,7 @@ const App: React.FC = () => {
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
               onUpdateFeatureDaName={handleUpdateFeatureDaName}
+              onUpdateFeatureLandCover={handleUpdateFeatureLandCover}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}
               onSelectFeatureForEditing={handleSelectFeatureForEditing}

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap, LayersControl, LayerGroup } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet-draw';
@@ -8,6 +8,7 @@ import AddressSearch from './AddressSearch';
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer';
 import type { LayerData } from '../types';
 import type { GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
+import { loadCnValues } from '../utils/cn';
 
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string | undefined;
 
@@ -15,6 +16,7 @@ interface MapComponentProps {
   layers: LayerData[];
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, lc: string) => void;
   zoomToLayer?: { id: string; ts: number } | null;
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
@@ -31,6 +33,8 @@ const ManagedGeoJsonLayer = ({
   isLastAdded,
   onUpdateFeatureHsg,
   onUpdateFeatureDaName,
+  onUpdateFeatureLandCover,
+  landCoverOptions,
   layerName,
   isEditingLayer,
   editingFeatureIndex,
@@ -43,6 +47,8 @@ const ManagedGeoJsonLayer = ({
   isLastAdded: boolean;
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, lc: string) => void;
+  landCoverOptions: string[];
   layerName: string;
   isEditingLayer: boolean;
   editingFeatureIndex: number | null;
@@ -124,9 +130,9 @@ const ManagedGeoJsonLayer = ({
 
       const propsDiv = L.DomUtil.create('div', '', container);
 
-      // Render all properties except HSG
+      // Render all properties except HSG and LAND_COVER
       Object.entries(feature.properties).forEach(([k, v]) => {
-        if (k === 'HSG') return;
+        if (k === 'HSG' || k === 'LAND_COVER') return;
         const row = L.DomUtil.create('div', '', propsDiv);
         row.innerHTML = `<b>${k}:</b> ${v}`;
       });
@@ -170,6 +176,30 @@ const ManagedGeoJsonLayer = ({
           const idx = data.features.indexOf(feature);
           onUpdateFeatureHsg(id, idx, newVal);
           feature.properties!.HSG = newVal;
+        });
+      }
+
+      if ('LAND_COVER' in feature.properties) {
+        const lcRow = L.DomUtil.create('div', '', propsDiv);
+        const label = L.DomUtil.create('b', '', lcRow);
+        label.textContent = 'Land Cover: ';
+        const select = L.DomUtil.create('select', '', lcRow) as HTMLSelectElement;
+        select.title = 'Seleccionar land cover';
+        select.style.marginLeft = '4px';
+        select.style.border = '2px solid #f59e0b';
+        select.style.backgroundColor = '#fef3c7';
+        select.style.fontWeight = 'bold';
+        landCoverOptions.forEach(val => {
+          const opt = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+          opt.value = val;
+          opt.textContent = val;
+          if (feature.properties!.LAND_COVER === val) opt.selected = true;
+        });
+        select.addEventListener('change', (e) => {
+          const newVal = (e.target as HTMLSelectElement).value;
+          const idx = data.features.indexOf(feature);
+          onUpdateFeatureLandCover(id, idx, newVal);
+          feature.properties!.LAND_COVER = newVal;
         });
       }
 
@@ -269,10 +299,12 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
 const GeomanControls = ({
   active,
   layer,
+  layerName,
   onChange,
 }: {
   active: boolean;
   layer: L.GeoJSON | null;
+  layerName?: string;
   onChange?: (geojson: LayerData['geojson']) => void;
 }) => {
   const map = useMap();
@@ -379,6 +411,14 @@ const GeomanControls = ({
     };
 
     const handleCreate = (e: any) => {
+      if (layerName === 'Land Cover') {
+        if (!e.layer.feature.properties) e.layer.feature.properties = {};
+        e.layer.feature.properties.LAND_COVER = '';
+      }
+      if (layerName === 'Soil Layer from Web Soil Survey') {
+        if (!e.layer.feature.properties) e.layer.feature.properties = {};
+        if (!('HSG' in e.layer.feature.properties)) e.layer.feature.properties.HSG = '';
+      }
       checkOverlap(e.layer);
       onChange && onChange(layer.toGeoJSON() as LayerData['geojson']);
     };
@@ -412,6 +452,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
   layers,
   onUpdateFeatureHsg,
   onUpdateFeatureDaName,
+  onUpdateFeatureLandCover,
   zoomToLayer,
   editingTarget,
   onSelectFeatureForEditing,
@@ -420,6 +461,13 @@ const MapComponent: React.FC<MapComponentProps> = ({
   onDiscardEdits,
 }) => {
   const layerRefs = useRef<Record<string, L.GeoJSON | null>>({});
+  const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    loadCnValues().then(data => {
+      if (data) setLandCoverOptions(Object.keys(data));
+    });
+  }, []);
 
   const handleSaveClick = () => {
     if (editingTarget?.layerId) {
@@ -437,6 +485,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
       <GeomanControls
         active={!!editingTarget?.layerId}
         layer={editingTarget?.layerId ? layerRefs.current[editingTarget.layerId] : null}
+        layerName={editingTarget?.layerId ? layers.find(l => l.id === editingTarget.layerId)?.name : undefined}
         onChange={(geo) => {
           if (editingTarget?.layerId && onUpdateLayerGeojson) {
             onUpdateLayerGeojson(editingTarget.layerId, geo);
@@ -522,6 +571,8 @@ const MapComponent: React.FC<MapComponentProps> = ({
                 isLastAdded={index === layers.length - 1}
                 onUpdateFeatureHsg={onUpdateFeatureHsg}
                 onUpdateFeatureDaName={onUpdateFeatureDaName}
+                onUpdateFeatureLandCover={onUpdateFeatureLandCover}
+                landCoverOptions={landCoverOptions}
                 layerName={layer.name}
                 isEditingLayer={editingTarget?.layerId === layer.id}
                 editingFeatureIndex={editingTarget?.layerId === layer.id ? editingTarget.featureIndex : null}

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,15 @@
+export async function loadCnValues(): Promise<Record<string, any> | null> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return await res.json();
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- fetch Curve Number table as needed
- support editing Land Cover with dropdown choices
- ensure Soil and Land Cover layers default to required attributes when loaded or drawn
- expose new `onUpdateFeatureLandCover` callback through Map

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68812e8d6f8c832087e613f7cf5cb0ec