### PR TITLE
Implement editable Land Cover and HSG dropdowns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { KNOWN_LAYER_NAMES } from './utils/constants';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
+type UpdateLandCoverFn = (layerId: string, featureIndex: number, cover: string) => void;
 
 const App: React.FC = () => {
   const [layers, setLayers] = useState<LayerData[]>([]);
@@ -61,6 +62,24 @@ const App: React.FC = () => {
         features: geojson.features.map(f => ({
           ...f,
           properties: { ...(f.properties || {}), DA_NAME: f.properties?.DA_NAME ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+    if (name === 'Land Cover') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), LAND_COVER: f.properties?.LAND_COVER ?? '' }
+        }))
+      } as FeatureCollection;
+    }
+    if (name === 'Soil Layer from Web Soil Survey') {
+      geojson = {
+        ...geojson,
+        features: geojson.features.map(f => ({
+          ...f,
+          properties: { ...(f.properties || {}), HSG: f.properties?.HSG ?? '' }
         }))
       } as FeatureCollection;
     }
@@ -131,6 +150,18 @@ const App: React.FC = () => {
       return { ...layer, geojson: { ...layer.geojson, features } };
     }));
     addLog(`Set HSG for feature ${featureIndex} in ${layerId} to ${hsg}`);
+  }, [addLog]);
+
+  const handleUpdateFeatureLandCover = useCallback<UpdateLandCoverFn>((layerId, featureIndex, cover) => {
+    setLayers(prev => prev.map(layer => {
+      if (layer.id !== layerId) return layer;
+      const features = [...layer.geojson.features];
+      const feature = { ...features[featureIndex] };
+      feature.properties = { ...(feature.properties || {}), LAND_COVER: cover };
+      features[featureIndex] = feature;
+      return { ...layer, geojson: { ...layer.geojson, features } };
+    }));
+    addLog(`Set Land Cover for feature ${featureIndex} in ${layerId} to ${cover}`);
   }, [addLog]);
 
   const handleUpdateFeatureDaName = useCallback<UpdateDaNameFn>((layerId, featureIndex, nameVal) => {
@@ -222,6 +253,7 @@ const App: React.FC = () => {
               layers={layers}
               onUpdateFeatureHsg={handleUpdateFeatureHsg}
               onUpdateFeatureDaName={handleUpdateFeatureDaName}
+              onUpdateFeatureLandCover={handleUpdateFeatureLandCover}
               zoomToLayer={zoomToLayer}
               editingTarget={editingTarget}
               onSelectFeatureForEditing={handleSelectFeatureForEditing}

--- a/utils/cn.ts
+++ b/utils/cn.ts
@@ -1,0 +1,39 @@
+export const DEFAULT_LAND_COVER_OPTIONS = [
+  'Open Space Poor condition (grass cover < 50%)',
+  'Open Space Fair condition (grass cover 50% to 75%)',
+  'Open Space Good condition (grass cover > 75%)',
+  'Impervious',
+  'Gravel',
+  'Dirt',
+  'Pasture, grassland, or range - Poor',
+  'Pasture, grassland, or range - Fair',
+  'Pasture, grassland, or range - Good',
+  'Meadow',
+  'Brush - Poor',
+  'Brush - Fair',
+  'Brush - Good',
+  'Woods Grass Combination - Poor',
+  'Woods Grass Combination - Fair',
+  'Woods Grass Combination - Good',
+  'Woods - Poor',
+  'Woods - Fair',
+  'Woods - Good',
+  'Water',
+  'Water - Process',
+];
+
+export async function loadCnValues(): Promise<Record<string, any> | null> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return await res.json();
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add utility to load CN values
- allow editing land cover values on the map
- ensure imported layers get LAND_COVER and HSG properties
- create default properties when drawing new features
- wire new dropdowns in the UI
- fix dropdown not showing options when CN values load late
- provide fallback land cover list

## Testing
- `npm install`
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68812e8d6f8c832087e613f7cf5cb0ec