### PR TITLE
Add land cover editing from CN values

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -15,6 +15,8 @@ interface MapComponentProps {
   layers: LayerData[];
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, value: string) => void;
+  landCoverOptions: string[];
   zoomToLayer?: { id: string; ts: number } | null;
   editingTarget?: { layerId: string | null; featureIndex: number | null };
   onSelectFeatureForEditing?: (layerId: string, index: number) => void;
@@ -31,6 +33,8 @@ const ManagedGeoJsonLayer = ({
   isLastAdded,
   onUpdateFeatureHsg,
   onUpdateFeatureDaName,
+  onUpdateFeatureLandCover,
+  landCoverOptions,
   layerName,
   isEditingLayer,
   editingFeatureIndex,
@@ -43,6 +47,8 @@ const ManagedGeoJsonLayer = ({
   isLastAdded: boolean;
   onUpdateFeatureHsg: (layerId: string, featureIndex: number, hsg: string) => void;
   onUpdateFeatureDaName: (layerId: string, featureIndex: number, name: string) => void;
+  onUpdateFeatureLandCover: (layerId: string, featureIndex: number, value: string) => void;
+  landCoverOptions: string[];
   layerName: string;
   isEditingLayer: boolean;
   editingFeatureIndex: number | null;
@@ -118,7 +124,8 @@ const ManagedGeoJsonLayer = ({
   const onEachFeature = (feature: GeoJSON.Feature, layer: Layer) => {
     if (feature.properties) {
       const container = L.DomUtil.create('div');
-      container.style.maxHeight = '150px';
+      container.style.maxHeight = '220px';
+      container.style.maxWidth = '360px';
       container.style.overflowY = 'auto';
       container.style.fontFamily = 'sans-serif';
 
@@ -205,6 +212,36 @@ const ManagedGeoJsonLayer = ({
           const idx = data.features.indexOf(feature);
           onUpdateFeatureDaName(id, idx, newVal);
           feature.properties!.DA_NAME = newVal;
+        });
+      }
+
+      // Editable land cover for Land Cover layers
+      if (layerName === 'Land Cover') {
+        const lcRow = L.DomUtil.create('div', '', propsDiv);
+        const lcLabel = L.DomUtil.create('b', '', lcRow);
+        lcLabel.textContent = 'Land Cover: ';
+        const select = L.DomUtil.create('select', '', lcRow) as HTMLSelectElement;
+        select.title = 'Seleccionar Land Cover';
+        select.style.marginLeft = '4px';
+        select.style.border = '2px solid #f97316';
+        select.style.backgroundColor = '#ffedd5';
+        select.style.fontWeight = 'bold';
+        select.style.width = '100%';
+        const blank = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+        blank.value = '';
+        blank.textContent = '--';
+        landCoverOptions.forEach(val => {
+          const opt = L.DomUtil.create('option', '', select) as HTMLOptionElement;
+          opt.value = val;
+          opt.textContent = val;
+          if (feature.properties!.LAND_COVER === val) opt.selected = true;
+        });
+        if (!feature.properties!.LAND_COVER) blank.selected = true;
+        select.addEventListener('change', (e) => {
+          const newVal = (e.target as HTMLSelectElement).value;
+          const idx = data.features.indexOf(feature);
+          onUpdateFeatureLandCover(id, idx, newVal);
+          feature.properties!.LAND_COVER = newVal;
         });
       }
 
@@ -412,6 +449,8 @@ const MapComponent: React.FC<MapComponentProps> = ({
   layers,
   onUpdateFeatureHsg,
   onUpdateFeatureDaName,
+  onUpdateFeatureLandCover,
+  landCoverOptions,
   zoomToLayer,
   editingTarget,
   onSelectFeatureForEditing,
@@ -522,6 +561,8 @@ const MapComponent: React.FC<MapComponentProps> = ({
                 isLastAdded={index === layers.length - 1}
                 onUpdateFeatureHsg={onUpdateFeatureHsg}
                 onUpdateFeatureDaName={onUpdateFeatureDaName}
+                onUpdateFeatureLandCover={onUpdateFeatureLandCover}
+                landCoverOptions={landCoverOptions}
                 layerName={layer.name}
                 isEditingLayer={editingTarget?.layerId === layer.id}
                 editingFeatureIndex={editingTarget?.layerId === layer.id ? editingTarget.featureIndex : null}

--- a/utils/landcover.ts
+++ b/utils/landcover.ts
@@ -1,0 +1,17 @@
+export async function loadLandCoverList(): Promise<string[]> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const list = Array.from(new Set((data as any[]).map(d => d.LandCover).filter(Boolean)));
+        return list;
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- load unique LandCover values from SCS_CN_VALUES.json
- keep land cover option state in the app and inject LAND_COVER field when uploading
- allow editing LAND_COVER property for "Land Cover" layers
- include dropdown of LandCover values in polygon popups
- pass new props through MapComponent and handle updates
- expand popup size for long land cover descriptions

## Testing
- `npm install`
- `npm run build`
- `node tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6881448af0c08320a9d2f1e5f2fc9283