### PR TITLE
Add upload preview and 'Other' layer type

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -115,6 +115,10 @@ const App: React.FC = () => {
     addLog('Loading file...');
   }, [addLog]);
 
+  const handleParsingComplete = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
   const handleError = useCallback((message: string) => {
     setIsLoading(false);
     setError(message);
@@ -241,6 +245,7 @@ const App: React.FC = () => {
             onLoading={handleLoading}
             onError={handleError}
             onLog={addLog}
+            onParsingComplete={handleParsingComplete}
             isLoading={isLoading}
             onCreateLayer={handleCreateLayer}
             existingLayerNames={layers.map(l => l.name)}


### PR DESCRIPTION
## Summary
- show a preview after shapefile upload to choose which category to assign
- allow assigning to new `Other` category (read-only)
- stop loading indicator when parsing is done

## Testing
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6881503486948320a5f96c0d8c358bd4