### PR TITLE
Add shapefile category preview with 'Other' type

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,7 +60,7 @@ const App: React.FC = () => {
       return;
     }
 
-    const editable = KNOWN_LAYER_NAMES.includes(name);
+    const editable = name !== 'Other' && KNOWN_LAYER_NAMES.includes(name);
 
     if (name === 'Drainage Areas') {
       geojson = {
@@ -92,11 +92,13 @@ const App: React.FC = () => {
       } as FeatureCollection;
     }
     setLayers(prevLayers => {
-      const existing = prevLayers.find(l => l.name === name);
-      if (existing) {
-        const updated = prevLayers.map(l => l.name === name ? { ...l, geojson, editable } : l);
-        addLog(`Updated layer ${name} with uploaded data`);
-        return updated;
+      if (name !== 'Other') {
+        const existing = prevLayers.find(l => l.name === name);
+        if (existing) {
+          const updated = prevLayers.map(l => l.name === name ? { ...l, geojson, editable } : l);
+          addLog(`Updated layer ${name} with uploaded data`);
+          return updated;
+        }
       }
       const newLayer: LayerData = {
         id: `${Date.now()}-${name}`,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ This allows the frontend to fetch the table of CN values based on soil group.
 
 These routes are ready for future integration with the frontend.
 
+## Layer categories
+
+When uploading shapefiles, the app attempts to identify the appropriate
+category (e.g. a Web Soil Survey file will map to *Soil Layer from Web Soil Survey*).
+Before the layer is added you can confirm or change this category. A new
+"Other" category is available for reference layers; any number of these may
+be added and they remain view-only.
+
 ## Update soil HSG mapping
 
 The file `public/data/soil-hsg-map.json` contains a mapping from soil map unit

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -4,7 +4,7 @@ import JSZip from 'jszip';
 import type { FeatureCollection } from 'geojson';
 import { UploadIcon } from './Icons';
 import { loadHsgMap } from '../utils/soil';
-import { ARCHIVE_NAME_MAP, KNOWN_LAYER_NAMES } from '../utils/constants';
+import { ARCHIVE_NAME_MAP, KNOWN_LAYER_NAMES, ALL_LAYER_NAMES } from '../utils/constants';
 
 interface FileUploadProps {
   onLayerAdded: (data: FeatureCollection, fileName: string) => void;
@@ -101,8 +101,13 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       }
       // --- END OF ENRICHMENT LOGIC ---
 
-      onLayerAdded(geojson, displayName);
-      onLog(`Loaded ${displayName}`);
+      const defaultCategory = ARCHIVE_NAME_MAP[lowerName] ?? (isWssFile ? 'Soil Layer from Web Soil Survey' : 'Other');
+      const promptMsg = `Detected ${geojson.features.length} features.\nAssign to category (${ALL_LAYER_NAMES.join(', ')}):`;
+      let chosen = window.prompt(promptMsg, defaultCategory) || defaultCategory;
+      if (!ALL_LAYER_NAMES.includes(chosen)) chosen = defaultCategory;
+
+      onLayerAdded(geojson, chosen);
+      onLog(`Loaded ${displayName} as ${chosen}`);
     } catch (e) {
       console.error("File parsing error:", e);
       const errMsg = "Failed to parse shapefile. Ensure the .zip contains valid .shp and .dbf files, and for WSS zips, that 'soilmu_a_aoi.shp' is present.";

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -10,3 +10,8 @@ export const KNOWN_LAYER_NAMES = [
   'LOD',
   'Soil Layer from Web Soil Survey',
 ];
+
+export const ALL_LAYER_NAMES = [
+  ...KNOWN_LAYER_NAMES,
+  'Other',
+];


### PR DESCRIPTION
## Summary
- prompt for category when uploading shapefiles
- allow multiple non-editable "Other" layers
- document layer categories and the new Other type

## Testing
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6881503486948320a5f96c0d8c358bd4