### PR TITLE
Add shapefile upload preview and new 'Other' layer type

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -115,6 +115,10 @@ const App: React.FC = () => {
     addLog('Loading file...');
   }, [addLog]);
 
+  const handlePreviewReady = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
   const handleError = useCallback((message: string) => {
     setIsLoading(false);
     setError(message);
@@ -239,6 +243,7 @@ const App: React.FC = () => {
           <FileUpload
             onLayerAdded={handleLayerAdded}
             onLoading={handleLoading}
+            onPreviewReady={handlePreviewReady}
             onError={handleError}
             onLog={addLog}
             isLoading={isLoading}

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -10,3 +10,5 @@ export const KNOWN_LAYER_NAMES = [
   'LOD',
   'Soil Layer from Web Soil Survey',
 ];
+
+export const LAYER_CATEGORIES = [...KNOWN_LAYER_NAMES, 'Other'];


### PR DESCRIPTION
## Summary
- allow preview and manual category assignment before loading shapefiles
- add new "Other" layer category for reference layers without editing

## Testing
- `node --test tests/intersect.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881503486948320a5f96c0d8c358bd4