### PR TITLE
Add shapefile preview option

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -14,9 +14,10 @@ interface FileUploadProps {
   isLoading: boolean;
   onCreateLayer?: (name: string) => void;
   existingLayerNames?: string[];
+  onPreviewReady?: (data: FeatureCollection, fileName: string, detectedName: string) => void;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading, onCreateLayer, existingLayerNames = [] }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onError, onLog, isLoading, onCreateLayer, existingLayerNames = [], onPreviewReady }) => {
   const [isDragging, setIsDragging] = useState(false);
   const availableNames = KNOWN_LAYER_NAMES.filter(n => !existingLayerNames.includes(n));
   const [newLayerName, setNewLayerName] = useState(availableNames[0] || '');
@@ -101,15 +102,20 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
       }
       // --- END OF ENRICHMENT LOGIC ---
 
-      onLayerAdded(geojson, displayName);
-      onLog(`Loaded ${displayName}`);
+      if (onPreviewReady) {
+        onPreviewReady(geojson, file.name, displayName);
+        onLog(`Preview ready for ${file.name}`);
+      } else {
+        onLayerAdded(geojson, displayName);
+        onLog(`Loaded ${displayName}`);
+      }
     } catch (e) {
       console.error("File parsing error:", e);
       const errMsg = "Failed to parse shapefile. Ensure the .zip contains valid .shp and .dbf files, and for WSS zips, that 'soilmu_a_aoi.shp' is present.";
       onError(errMsg);
       onLog(errMsg, 'error');
     }
-  }, [onLayerAdded, onLoading, onError, onLog]);
+  }, [onLayerAdded, onLoading, onError, onLog, onPreviewReady]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/components/LayerPreview.tsx
+++ b/components/LayerPreview.tsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import type { FeatureCollection } from 'geojson';
+import { ALL_LAYER_NAMES, KNOWN_LAYER_NAMES, OTHER_CATEGORY } from '../utils/constants';
+
+interface LayerPreviewProps {
+  data: FeatureCollection;
+  fileName: string;
+  detectedName: string;
+  onConfirm: (name: string, data: FeatureCollection) => void;
+  onCancel: () => void;
+}
+
+const LayerPreview: React.FC<LayerPreviewProps> = ({ data, fileName, detectedName, onConfirm, onCancel }) => {
+  const [category, setCategory] = useState<string>(OTHER_CATEGORY);
+
+  useEffect(() => {
+    if (KNOWN_LAYER_NAMES.includes(detectedName)) {
+      setCategory(detectedName);
+    } else {
+      setCategory(OTHER_CATEGORY);
+    }
+  }, [detectedName]);
+
+  const handleConfirm = () => {
+    const base = fileName.replace(/\.zip$/i, '');
+    const finalName = category === OTHER_CATEGORY ? `Other - ${base}` : category;
+    onConfirm(finalName, data);
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded-lg border border-gray-600 space-y-3">
+      <h3 className="text-md font-semibold text-cyan-400">Preview {fileName}</h3>
+      <p className="text-sm text-gray-300">Detected as: <span className="font-mono">{detectedName}</span></p>
+      <div className="flex space-x-2 items-center">
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="flex-grow bg-gray-700 border border-gray-600 text-gray-200 rounded px-2 py-1"
+        >
+          {ALL_LAYER_NAMES.map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="bg-cyan-600 hover:bg-cyan-700 text-white px-3 py-1 rounded"
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1 rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LayerPreview;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -10,3 +10,6 @@ export const KNOWN_LAYER_NAMES = [
   'LOD',
   'Soil Layer from Web Soil Survey',
 ];
+
+export const OTHER_CATEGORY = 'Other';
+export const ALL_LAYER_NAMES = [...KNOWN_LAYER_NAMES, OTHER_CATEGORY];


### PR DESCRIPTION
## Summary
- create `Other` category for view-only shapefiles
- allow shapefile uploads to be previewed and classified before adding
- update constants and add new `LayerPreview` component

## Testing
- `npm install`
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6881503486948320a5f96c0d8c358bd4