### PR TITLE
Enable Compute button when required layers loaded

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,9 @@ const App: React.FC = () => {
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
   const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
 
+  const requiredLayers = ['Drainage Areas', 'Land Cover', 'LOD', 'Soil Layer from Web Soil Survey'];
+  const computeEnabled = requiredLayers.every(name => layers.some(l => l.name === name));
+
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
   }, []);
@@ -250,9 +253,13 @@ const App: React.FC = () => {
     addLog('Preview canceled');
   }, [addLog]);
 
+  const handleCompute = useCallback(() => {
+    addLog('Compute clicked');
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header />
+      <Header computeEnabled={computeEnabled} onCompute={handleCompute} />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,14 +2,26 @@
 import React from 'react';
 import { MapIcon } from './Icons';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onCompute?: () => void;
+  computeEnabled?: boolean;
+}
+const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
   return (
-    <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
+    <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
       <div>
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
+      {computeEnabled && (
+        <button
+          onClick={onCompute}
+          className="absolute left-1/2 -translate-x-1/2 bg-cyan-600 hover:bg-cyan-700 text-white font-semibold px-4 py-1 rounded"
+        >
+          Compute
+        </button>
+      )}
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- show Compute button in the header when Drainage Areas, Land Cover, LOD, and WSS layers are loaded
- pass action to Header and display button centered over the header text

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688155143b50832089c81b96d9859765