### PR TITLE
Add compute button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,13 @@ const App: React.FC = () => {
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
   const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
 
+  const REQUIRED_LAYERS = [
+    'Drainage Areas',
+    'Land Cover',
+    'LOD',
+    'Soil Layer from Web Soil Survey',
+  ];
+
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
   }, []);
@@ -250,9 +257,17 @@ const App: React.FC = () => {
     addLog('Preview canceled');
   }, [addLog]);
 
+  const canCompute = REQUIRED_LAYERS.every(name =>
+    layers.some(layer => layer.name === name)
+  );
+
+  const handleCompute = useCallback(() => {
+    addLog('Compute triggered');
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header />
+      <Header canCompute={canCompute} onCompute={handleCompute} />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,7 +2,11 @@
 import React from 'react';
 import { MapIcon } from './Icons';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  canCompute?: boolean;
+  onCompute?: () => void;
+}
+const Header: React.FC<HeaderProps> = ({ canCompute = false, onCompute }) => {
   return (
     <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
@@ -10,6 +14,14 @@ const Header: React.FC = () => {
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
+      {canCompute && (
+        <button
+          onClick={onCompute}
+          className="ml-auto bg-cyan-600 hover:bg-cyan-700 text-white font-semibold px-4 py-1 rounded"
+        >
+          Compute
+        </button>
+      )}
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- require drainage area, land cover, LOD and WSS layers before enabling compute
- show a `Compute` button in the header when layers are present

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688155143b50832089c81b96d9859765