### PR TITLE
Add compute button for workflow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import type { FeatureCollection } from 'geojson';
 import type { LayerData, LogEntry } from './types';
 import Header from './components/Header';
@@ -24,6 +24,12 @@ const App: React.FC = () => {
   const [editingBackup, setEditingBackup] = useState<{ layerId: string; geojson: FeatureCollection } | null>(null);
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
   const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
+
+  const requiredLayers = ['Drainage Areas', 'Land Cover', 'LOD', 'Soil Layer from Web Soil Survey'];
+  const computeEnabled = useMemo(
+    () => requiredLayers.every(name => layers.some(l => l.name === name)),
+    [layers]
+  );
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' }]);
@@ -250,9 +256,13 @@ const App: React.FC = () => {
     addLog('Preview canceled');
   }, [addLog]);
 
+  const handleCompute = useCallback(() => {
+    addLog('Compute triggered');
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header />
+      <Header computeEnabled={computeEnabled} onCompute={handleCompute} />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,13 +2,28 @@
 import React from 'react';
 import { MapIcon } from './Icons';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  computeEnabled?: boolean;
+  onCompute?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ computeEnabled = false, onCompute }) => {
   return (
-    <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
+    <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center relative space-x-2 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
-      <div>
-        <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
-        <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
+      <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
+      <div className="absolute left-1/2 -translate-x-1/2">
+        {computeEnabled ? (
+          <button
+            type="button"
+            onClick={onCompute}
+            className="bg-cyan-600 hover:bg-cyan-700 text-white font-semibold px-4 py-1 rounded shadow"
+          >
+            Compute
+          </button>
+        ) : (
+          <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add Compute button to header
- show Compute when Drainage, Land Cover, LOD, and WSS layers are loaded
- log placeholder message when Compute is clicked

## Testing
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688155143b50832089c81b96d9859765