### PR TITLE
Enable Compute button when layers ready

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,14 +2,30 @@
 import React from 'react';
 import { MapIcon } from './Icons';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onCompute?: () => void;
+  computeEnabled?: boolean;
+}
+const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
   return (
-    <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
+    <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
       <div>
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
+      <button
+        onClick={onCompute}
+        disabled={!computeEnabled}
+        className={
+          'absolute left-1/2 -translate-x-1/2 font-semibold px-4 py-1 rounded ' +
+          (computeEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        Compute
+      </button>
     </header>
   );
 };

--- a/components/TaskModal.tsx
+++ b/components/TaskModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { CheckCircleIcon, XCircleIcon } from './Icons';
+
+export interface TaskItem {
+  id: string;
+  description: string;
+  status: 'pending' | 'success' | 'error';
+}
+
+interface TaskModalProps {
+  tasks: TaskItem[];
+  onClose?: () => void;
+}
+
+const TaskModal: React.FC<TaskModalProps> = ({ tasks, onClose }) => {
+  const allDone = tasks.every(t => t.status !== 'pending');
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-gray-800 border border-gray-600 p-6 rounded-lg w-80 space-y-4">
+        <h2 className="text-lg font-semibold text-white">Processing</h2>
+        <ul className="space-y-2">
+          {tasks.map(task => (
+            <li key={task.id} className="flex items-center text-gray-300">
+              {task.status === 'success' && (
+                <CheckCircleIcon className="w-5 h-5 text-green-400 mr-2" />
+              )}
+              {task.status === 'error' && (
+                <XCircleIcon className="w-5 h-5 text-red-400 mr-2" />
+              )}
+              {task.status === 'pending' && (
+                <svg className="animate-spin w-5 h-5 text-gray-400 mr-2" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                </svg>
+              )}
+              <span className="flex-1">{task.description}</span>
+            </li>
+          ))}
+        </ul>
+        {allDone && (
+          <button
+            onClick={onClose}
+            className="block ml-auto bg-cyan-600 hover:bg-cyan-700 text-white px-4 py-1 rounded"
+          >
+            Close
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskModal;


### PR DESCRIPTION
## Summary
- keep Compute button visible in the header
- disable button until Drainage Areas, Land Cover, LOD and WSS layers are loaded
- launch a task modal when Compute is clicked
- perform an intersection of required layers and create an `Intersection 1` layer

## Testing
- `npm run build`
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688155143b50832089c81b96d9859765