### PR TITLE
Add compute modal and intersection step

### DIFF
--- a/components/ComputeModal.tsx
+++ b/components/ComputeModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { CheckCircleIcon, XCircleIcon, InfoIcon } from './Icons';
+
+export interface ComputeTask {
+  name: string;
+  status: 'pending' | 'success' | 'error';
+}
+
+interface ComputeModalProps {
+  tasks: ComputeTask[];
+  onClose: () => void;
+}
+
+const ComputeModal: React.FC<ComputeModalProps> = ({ tasks, onClose }) => {
+  return (
+    <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 space-y-4 w-80">
+        <h2 className="text-lg font-semibold text-white">Compute</h2>
+        <ul className="space-y-2">
+          {tasks.map(task => (
+            <li key={task.name} className="flex items-center space-x-2 text-gray-300">
+              {task.status === 'success' && <CheckCircleIcon className="w-5 h-5 text-green-400" />}
+              {task.status === 'error' && <XCircleIcon className="w-5 h-5 text-red-400" />}
+              {task.status === 'pending' && <InfoIcon className="w-5 h-5 text-gray-400 animate-pulse" />}
+              <span>{task.name}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="text-right">
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-cyan-600 hover:bg-cyan-700 text-white px-3 py-1 rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ComputeModal;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,14 +2,30 @@
 import React from 'react';
 import { MapIcon } from './Icons';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onCompute?: () => void;
+  computeEnabled?: boolean;
+}
+const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
   return (
-    <header className="bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
+    <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
       <div>
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
+      <button
+        onClick={onCompute}
+        disabled={!computeEnabled}
+        className={
+          'absolute left-1/2 -translate-x-1/2 font-semibold px-4 py-1 rounded ' +
+          (computeEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        Compute
+      </button>
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- display Compute modal with tasks when Compute is clicked
- perform LOD intersection with Drainage Areas, Land Cover and WSS layers
- add resulting features as "Intersection 1" layer

## Testing
- `npm install`
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688155143b50832089c81b96d9859765