### PR TITLE
Refactor compute workflow and update instructions

### DIFF
--- a/components/InstructionsPage.tsx
+++ b/components/InstructionsPage.tsx
@@ -6,7 +6,14 @@ const InstructionsPage: React.FC = () => {
       <div className="max-w-prose text-center space-y-4">
         <h2 className="text-2xl font-bold text-cyan-400">Welcome</h2>
         <p>Upload a shapefile using the panel on the left to start the map.</p>
-        <p className="text-gray-500">// TODO: Add detailed instructions here</p>
+        <ol className="list-decimal list-inside text-left space-y-2">
+          <li>Verify the LOD layer contains exactly one polygon.</li>
+          <li>
+            Use that polygon to clip the Drainage Areas layer and save the
+            result as <strong>Drainage Area in LOD</strong>, preserving all
+            original attributes.
+          </li>
+        </ol>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- adjust required layers for compute workflow
- rework compute logic into two smaller steps: check LOD polygon count and clip Drainage Areas
- add instructions describing the steps

## Testing
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68816067a3d083209f69d82492fa1843