### PR TITLE
Add overlay step to compute workflow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -110,6 +110,7 @@ const App: React.FC = () => {
         name,
         geojson,
         editable,
+        category: 'Original',
       };
       addLog(`Loaded layer ${name}${editable ? '' : ' (view only)'}`);
       return [...prevLayers, newLayer];
@@ -146,6 +147,7 @@ const App: React.FC = () => {
         name,
         geojson: { type: 'FeatureCollection', features: [] },
         editable: true,
+        category: 'Original',
       };
       addLog(`Created new layer ${name}`);
       return [...prev, newLayer];
@@ -258,65 +260,116 @@ const App: React.FC = () => {
   const runCompute = useCallback(async () => {
     const lod = layers.find(l => l.name === 'LOD');
     const da = layers.find(l => l.name === 'Drainage Areas');
-    if (!lod || !da) return;
+    const wss = layers.find(l => l.name === 'Soil Layer from Web Soil Survey');
+    const lc = layers.find(l => l.name === 'Land Cover');
+    if (!lod) return;
 
     const tasks: ComputeTask[] = [
       { id: 'check_lod', name: 'Check LOD has one polygon', status: 'pending' },
-      { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'pending' }
+      { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'pending' },
+      { id: 'clip_wss', name: 'Create WSS in LOD', status: 'pending' },
+      { id: 'clip_lc', name: 'Create Land Cover in LOD', status: 'pending' },
+      { id: 'overlay', name: 'Overlay Processed Layers', status: 'pending' },
     ];
     setComputeTasks(tasks);
 
+    setLayers(prev => prev.filter(l => l.category !== 'Process'));
+
     if (lod.geojson.features.length !== 1) {
-      setComputeTasks([
-        { id: 'check_lod', name: 'Check LOD has one polygon', status: 'error' },
-        { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'error' }
-      ]);
+      setComputeTasks(prev => prev.map(t => ({ ...t, status: 'error' })));
       addLog('LOD layer must contain exactly one polygon', 'error');
       return;
     }
 
-    setComputeTasks([
-      { id: 'check_lod', name: 'Check LOD has one polygon', status: 'success' },
-      { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'pending' }
-    ]);
+    setComputeTasks(prev => prev.map(t => t.id === 'check_lod' ? { ...t, status: 'success' } : t));
 
     try {
-      const { intersect } = await import('@turf/turf');
+      const { intersect, featureCollection } = await import('@turf/turf');
       const lodGeom = lod.geojson.features[0];
-      const clipped: any[] = [];
-      da.geojson.features.forEach(f => {
-        const inter = intersect(f as any, lodGeom as any);
-        if (inter) {
-          inter.properties = { ...(f.properties || {}) };
-          clipped.push(inter);
-        }
-      });
 
-      if (clipped.length > 0) {
-        const newLayer: LayerData = {
-          id: `${Date.now()}-Drainage Area in LOD`,
-          name: 'Drainage Area in LOD',
-          geojson: { type: 'FeatureCollection', features: clipped } as FeatureCollection,
-          editable: true,
-        };
-        setLayers(prev => [...prev, newLayer]);
-        setComputeTasks([
-          { id: 'check_lod', name: 'Check LOD has one polygon', status: 'success' },
-          { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'success' }
-        ]);
-        addLog('Drainage Area in LOD created');
+      const resultLayers: LayerData[] = [];
+
+      const processLayer = (source: typeof da | typeof wss | typeof lc | undefined, taskId: string, name: string) => {
+        if (!source) return;
+        const clipped: any[] = [];
+        source.geojson.features.forEach(f => {
+          const fc = featureCollection([f as any, lodGeom as any]);
+          const inter = intersect(fc as any);
+          if (inter) {
+            inter.properties = { ...(f.properties || {}) };
+            clipped.push(inter);
+          }
+        });
+        if (clipped.length > 0) {
+          resultLayers.push({
+            id: `${Date.now()}-${name}`,
+            name,
+            geojson: { type: 'FeatureCollection', features: clipped } as FeatureCollection,
+            editable: true,
+            category: 'Process',
+          });
+          setComputeTasks(prev => prev.map(t => t.id === taskId ? { ...t, status: 'success' } : t));
+          addLog(`${name} created`);
+        } else {
+          setComputeTasks(prev => prev.map(t => t.id === taskId ? { ...t, status: 'error' } : t));
+          addLog(`No features for ${name}`, 'error');
+        }
+      };
+
+      processLayer(da, 'clip_da', 'Drainage Area in LOD');
+      processLayer(wss, 'clip_wss', 'WSS in LOD');
+      processLayer(lc, 'clip_lc', 'Land Cover in LOD');
+
+      const daLayer = resultLayers.find(l => l.name === 'Drainage Area in LOD');
+      const wssLayer = resultLayers.find(l => l.name === 'WSS in LOD');
+      const lcLayer = resultLayers.find(l => l.name === 'Land Cover in LOD');
+
+      if (daLayer && wssLayer && lcLayer) {
+        const combined: any[] = [];
+        daLayer.geojson.features.forEach(f1 => {
+          wssLayer.geojson.features.forEach(f2 => {
+            const fc1 = featureCollection([f1 as any, f2 as any]);
+            const inter12 = intersect(fc1 as any);
+            if (!inter12) return;
+            lcLayer.geojson.features.forEach(f3 => {
+              const fc2 = featureCollection([inter12 as any, f3 as any]);
+              const inter123 = intersect(fc2 as any);
+              if (inter123) {
+                inter123.properties = {
+                  ...(f1.properties || {}),
+                  ...(f2.properties || {}),
+                  ...(f3.properties || {}),
+                };
+                combined.push(inter123);
+              }
+            });
+          });
+        });
+        if (combined.length > 0) {
+          resultLayers.push({
+            id: `${Date.now()}-Overlay`,
+            name: 'Overlayed Process Layers',
+            geojson: { type: 'FeatureCollection', features: combined } as FeatureCollection,
+            editable: true,
+            category: 'Process',
+          });
+          setComputeTasks(prev => prev.map(t => t.id === 'overlay' ? { ...t, status: 'success' } : t));
+          addLog('Overlayed Process Layers created');
+        } else {
+          setComputeTasks(prev => prev.map(t => t.id === 'overlay' ? { ...t, status: 'error' } : t));
+          addLog('No overlay result', 'error');
+        }
       } else {
-        setComputeTasks([
-          { id: 'check_lod', name: 'Check LOD has one polygon', status: 'success' },
-          { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'error' }
-        ]);
-        addLog('No drainage areas intersect the LOD', 'error');
+        setComputeTasks(prev => prev.map(t => t.id === 'overlay' ? { ...t, status: 'error' } : t));
+        addLog('Missing layers for overlay', 'error');
       }
+
+      setLayers(prev => {
+        const withoutProcess = prev.filter(l => l.category !== 'Process');
+        return [...withoutProcess, ...resultLayers];
+      });
     } catch (err) {
-      setComputeTasks([
-        { id: 'check_lod', name: 'Check LOD has one polygon', status: 'success' },
-        { id: 'clip_da', name: 'Create Drainage Area in LOD', status: 'error' }
-      ]);
+      setComputeTasks(prev => prev.map(t => t.status === 'pending' ? { ...t, status: 'error' } : t));
       addLog('Processing failed', 'error');
     }
   }, [layers, setLayers, addLog]);

--- a/components/InfoPanel.tsx
+++ b/components/InfoPanel.tsx
@@ -50,47 +50,100 @@ const InfoPanel: React.FC<InfoPanelProps> = ({ layers, error, logs, onRemoveLaye
         )}
         {layers.length > 0 && (
            <div className="space-y-3">
-            {layers.map((layer) => {
-              const featureCount = layer.geojson.features.length;
-              const featureSummary = getFeatureTypeSummary(layer.geojson);
-              return (
-                <div
-                  key={layer.id}
-                  className="bg-gray-800 p-4 rounded-lg border border-gray-600/50 cursor-pointer hover:border-cyan-400"
-                  onClick={() => onZoomToLayer && onZoomToLayer(layer.id)}
-                >
-                  <div className="flex justify-between items-start">
-                    <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
-                    <div className="flex space-x-2">
-                      {onToggleEditLayer && (layer.editable ? (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
-                          className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
-                          aria-label={`Edit layer ${layer.name}`}
+            {Object.entries(layers.reduce((acc: Record<string, LayerData[]>, l) => {
+                const cat = l.category || 'Original';
+                (acc[cat] = acc[cat] || []).push(l);
+                return acc;
+              }, {})).map(([cat, grp]) => (
+                cat === 'Process' ? (
+                  <details key={cat} open className="space-y-3">
+                    <summary className="cursor-pointer text-cyan-300 font-bold">{cat}</summary>
+                    {grp.map(layer => {
+                      const featureCount = layer.geojson.features.length;
+                      const featureSummary = getFeatureTypeSummary(layer.geojson);
+                      return (
+                        <div
+                          key={layer.id}
+                          className="bg-gray-800 p-4 rounded-lg border border-gray-600/50 cursor-pointer hover:border-cyan-400"
+                          onClick={() => onZoomToLayer && onZoomToLayer(layer.id)}
                         >
-                          {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
-                        </button>
-                      ) : (
-                        <LockClosedIcon className="w-5 h-5 text-gray-600" />
-                      ))}
-                      <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
-                        <TrashIcon className="w-5 h-5" />
-                      </button>
-                    </div>
-                  </div>
-                  <div className="text-gray-300 space-y-2 text-sm">
-                     <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{featureCount}</span></p>
-                      {Object.keys(featureSummary).length > 0 && (
-                          <ul className="list-disc list-inside space-y-1 text-xs text-gray-400 pl-1">
-                            {Object.entries(featureSummary).map(([type, count]) => (
-                              <li key={type}>{type}: <span className="font-mono text-cyan-400">{count}</span></li>
+                          <div className="flex justify-between items-start">
+                            <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
+                            <div className="flex space-x-2">
+                              {onToggleEditLayer && (layer.editable ? (
+                                <button
+                                  onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
+                                  className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
+                                  aria-label={`Edit layer ${layer.name}`}
+                                >
+                                  {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
+                                </button>
+                              ) : (
+                                <LockClosedIcon className="w-5 h-5 text-gray-600" />
+                              ))}
+                              <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
+                                <TrashIcon className="w-5 h-5" />
+                              </button>
+                            </div>
+                          </div>
+                          <div className="text-gray-300 space-y-2 text-sm">
+                             <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{featureCount}</span></p>
+                              {Object.keys(featureSummary).length > 0 && (
+                                  <ul className="list-disc list-inside space-y-1 text-xs text-gray-400 pl-1">
+                                    {Object.entries(featureSummary).map(([type, count]) => (
+                                      <li key={type}>{type}: <span className="font-mono text-cyan-400">{count}</span></li>
+                                    ))}
+                                  </ul>
+                              )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </details>
+                ) : (
+                  grp.map(layer => {
+                    const featureCount = layer.geojson.features.length;
+                    const featureSummary = getFeatureTypeSummary(layer.geojson);
+                    return (
+                      <div
+                        key={layer.id}
+                        className="bg-gray-800 p-4 rounded-lg border border-gray-600/50 cursor-pointer hover:border-cyan-400"
+                        onClick={() => onZoomToLayer && onZoomToLayer(layer.id)}
+                      >
+                        <div className="flex justify-between items-start">
+                          <h3 className="text-md font-bold text-cyan-400 mb-2 break-all pr-2">{layer.name}</h3>
+                          <div className="flex space-x-2">
+                            {onToggleEditLayer && (layer.editable ? (
+                              <button
+                                onClick={(e) => { e.stopPropagation(); onToggleEditLayer(layer.id); }}
+                                className="text-gray-500 hover:text-green-400 transition-colors flex-shrink-0"
+                                aria-label={`Edit layer ${layer.name}`}
+                              >
+                                {editingLayerId === layer.id ? <XCircleIcon className="w-5 h-5" /> : <EditIcon className="w-5 h-5" />}
+                              </button>
+                            ) : (
+                              <LockClosedIcon className="w-5 h-5 text-gray-600" />
                             ))}
-                          </ul>
-                      )}
-                  </div>
-                </div>
-              );
-            })}
+                            <button onClick={(e) => { e.stopPropagation(); onRemoveLayer(layer.id); }} className="text-gray-500 hover:text-red-400 transition-colors flex-shrink-0" aria-label={`Remove layer ${layer.name}`}>
+                              <TrashIcon className="w-5 h-5" />
+                            </button>
+                          </div>
+                        </div>
+                        <div className="text-gray-300 space-y-2 text-sm">
+                           <p><strong>Total Features:</strong> <span className="font-mono bg-gray-900 px-2 py-1 rounded">{featureCount}</span></p>
+                            {Object.keys(featureSummary).length > 0 && (
+                                <ul className="list-disc list-inside space-y-1 text-xs text-gray-400 pl-1">
+                                  {Object.entries(featureSummary).map(([type, count]) => (
+                                    <li key={type}>{type}: <span className="font-mono text-cyan-400">{count}</span></li>
+                                  ))}
+                                </ul>
+                            )}
+                        </div>
+                      </div>
+                    );
+                  })
+                )
+              ))}
           </div>
         )}
       </div>

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface LayerData {
   name: string;
   geojson: FeatureCollection;
   editable: boolean;
+  category?: string;
 }
 
 export interface LogEntry {


### PR DESCRIPTION
## Summary
- overlay clipped layers to create an additional `Overlayed Process Layers` layer
- show overlay step progress in Compute modal

## Testing
- `npm install`
- `node --test tests/intersect.test.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68816351ec2483208ab02440e6137982