### PR TITLE
Compute CN values on overlay

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import InstructionsPage from './components/InstructionsPage';
 import { KNOWN_LAYER_NAMES } from './utils/constants';
 import LayerPreview from './components/LayerPreview';
 import ComputeModal, { ComputeTask } from './components/ComputeModal';
-import { loadLandCoverList } from './utils/landcover';
+import { loadLandCoverList, loadCnValues, CnRecord } from './utils/landcover';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
@@ -372,6 +372,19 @@ const App: React.FC = () => {
               }
             });
           });
+        });
+
+        // Load CN values and assign CN attribute
+        const cnRecords = await loadCnValues();
+        const cnMap = new Map(cnRecords.map(r => [r.LandCover, r]));
+        overlay.forEach(f => {
+          const lcName = (f.properties as any)?.LAND_COVER;
+          const hsg = (f.properties as any)?.HSG;
+          const rec = lcName ? cnMap.get(lcName) : undefined;
+          const cnValue = rec ? (rec as any)[hsg as keyof CnRecord] : undefined;
+          if (cnValue !== undefined) {
+            f.properties = { ...(f.properties || {}), CN: cnValue };
+          }
         });
 
         if (overlay.length > 0) {

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -133,9 +133,9 @@ const ManagedGeoJsonLayer = ({
 
       const propsDiv = L.DomUtil.create('div', '', container);
 
-      // Render all properties except HSG
+      // Render all properties except HSG when editable
       Object.entries(feature.properties).forEach(([k, v]) => {
-        if (k === 'HSG') return;
+        if (k === 'HSG' && layerName === 'Soil Layer from Web Soil Survey') return;
         const row = L.DomUtil.create('div', '', propsDiv);
         row.innerHTML = `<b>${k}:</b> ${v}`;
       });
@@ -158,7 +158,7 @@ const ManagedGeoJsonLayer = ({
       layer.on('pm:update', updateArea);
 
       // Special editable field for HSG
-      if (layerName === 'Soil Layer from Web Soil Survey' || 'HSG' in feature.properties) {
+      if (layerName === 'Soil Layer from Web Soil Survey') {
         feature.properties = { ...(feature.properties || {}), HSG: feature.properties?.HSG ?? '' };
         const hsgRow = L.DomUtil.create('div', '', propsDiv);
         const label = L.DomUtil.create('b', '', hsgRow);
@@ -185,6 +185,9 @@ const ManagedGeoJsonLayer = ({
           onUpdateFeatureHsg(id, idx, newVal);
           feature.properties!.HSG = newVal;
         });
+      } else if ('HSG' in feature.properties) {
+        const hsgRow = L.DomUtil.create('div', '', propsDiv);
+        hsgRow.innerHTML = `<b>HSG:</b> ${feature.properties!.HSG}`;
       }
 
       // Editable name for Drainage Areas

--- a/utils/landcover.ts
+++ b/utils/landcover.ts
@@ -15,3 +15,27 @@ export async function loadLandCoverList(): Promise<string[]> {
   }
   return [];
 }
+
+export interface CnRecord {
+  LandCover: string;
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+}
+
+export async function loadCnValues(): Promise<CnRecord[]> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return (await res.json()) as CnRecord[];
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- compute CN for overlay polygons from CN lookup
- load CN lookup via `loadCnValues`
- show HSG as read-only except on soil layer

## Testing
- `npm install`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688269d4b1388320abd9c38dc70b1d8e