### PR TITLE
Compute CN values and lock HSG editing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import InstructionsPage from './components/InstructionsPage';
 import { KNOWN_LAYER_NAMES } from './utils/constants';
 import LayerPreview from './components/LayerPreview';
 import ComputeModal, { ComputeTask } from './components/ComputeModal';
-import { loadLandCoverList } from './utils/landcover';
+import { loadLandCoverList, loadCnTable, lookupCurveNumber } from './utils/landcover';
 
 type UpdateHsgFn = (layerId: string, featureIndex: number, hsg: string) => void;
 type UpdateDaNameFn = (layerId: string, featureIndex: number, name: string) => void;
@@ -311,6 +311,7 @@ const App: React.FC = () => {
 
     try {
       const { intersect, featureCollection } = await import('@turf/turf');
+      const cnTable = await loadCnTable();
       const lodGeom = lod.geojson.features[0];
 
 
@@ -368,6 +369,12 @@ const App: React.FC = () => {
                   ...(wssF.properties || {}),
                   ...(lcF.properties || {})
                 };
+                const lcName = inter2.properties.LAND_COVER as string;
+                const hsgVal = inter2.properties.HSG as string;
+                const cnVal = lookupCurveNumber(cnTable, lcName, hsgVal);
+                if (cnVal !== null) {
+                  inter2.properties.CN = cnVal;
+                }
                 overlay.push(inter2);
               }
             });

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -158,7 +158,7 @@ const ManagedGeoJsonLayer = ({
       layer.on('pm:update', updateArea);
 
       // Special editable field for HSG
-      if (layerName === 'Soil Layer from Web Soil Survey' || 'HSG' in feature.properties) {
+      if (layerName === 'Soil Layer from Web Soil Survey') {
         feature.properties = { ...(feature.properties || {}), HSG: feature.properties?.HSG ?? '' };
         const hsgRow = L.DomUtil.create('div', '', propsDiv);
         const label = L.DomUtil.create('b', '', hsgRow);

--- a/utils/landcover.ts
+++ b/utils/landcover.ts
@@ -15,3 +15,37 @@ export async function loadLandCoverList(): Promise<string[]> {
   }
   return [];
 }
+
+export async function loadCnTable(): Promise<Record<string, Record<string, number>> | null> {
+  const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
+  for (const url of sources) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const table: Record<string, Record<string, number>> = {};
+        (data as any[]).forEach(row => {
+          const lc = row.LandCover;
+          if (!table[lc]) table[lc] = {} as Record<string, number>;
+          table[lc]['A'] = row.A;
+          table[lc]['B'] = row.B;
+          table[lc]['C'] = row.C;
+          table[lc]['D'] = row.D;
+        });
+        return table;
+      }
+      console.warn(`CN values request to ${url} failed with status ${res.status}`);
+    } catch (err) {
+      console.warn(`CN values request to ${url} failed`, err);
+    }
+  }
+  return null;
+}
+
+export function lookupCurveNumber(table: Record<string, Record<string, number>> | null, landCover: string, hsg: string): number | null {
+  if (!table) return null;
+  const row = table[landCover];
+  if (!row) return null;
+  const value = row[hsg];
+  return typeof value === 'number' ? value : null;
+}


### PR DESCRIPTION
## Summary
- disable HSG dropdown for non‑WSS layers so overlay results aren't editable
- expose functions to load curve number table and lookup values
- during compute overlay step, attach CN value based on land cover and HSG

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_688269d4b1388320abd9c38dc70b1d8e