### PR TITLE
Show only Overlay layer after compute

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -457,7 +457,13 @@ const App: React.FC = () => {
 
       setLayers(prev => {
         const withoutProcess = prev.filter(l => l.category !== 'Process');
-        return [...withoutProcess, ...resultLayers];
+        let finalLayers = [...withoutProcess, ...resultLayers];
+        if (finalLayers.some(l => l.name === 'Overlay')) {
+          finalLayers = finalLayers.map(l =>
+            l.name === 'Overlay' ? { ...l, visible: true } : { ...l, visible: false }
+          );
+        }
+        return finalLayers;
       });
     } catch (err) {
       setComputeTasks(prev => prev.map(t => t.status === 'pending' ? { ...t, status: 'error' } : t));


### PR DESCRIPTION
## Summary
- update compute to make "Overlay" the only visible layer after compute

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68839a8bfe548320b037badc717b0bfe