### PR TITLE
Add HydroCAD export button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -59,6 +59,9 @@ const App: React.FC = () => {
   const computeEnabled =
     requiredLayers.every(name => layers.some(l => l.name === name)) && lodValid;
 
+  const exportEnabled =
+    computeTasks !== null && computeTasks.every(t => t.status === 'success');
+
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' as const }]);
   }, []);
@@ -475,9 +478,18 @@ const App: React.FC = () => {
     runCompute();
   }, [runCompute]);
 
+  const handleExportHydroCAD = useCallback(() => {
+    // Export functionality will be implemented in the future
+  }, []);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header computeEnabled={computeEnabled} onCompute={handleCompute} />
+      <Header
+        computeEnabled={computeEnabled}
+        onCompute={handleCompute}
+        onExportHydroCAD={handleExportHydroCAD}
+        exportEnabled={exportEnabled}
+      />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,15 @@ import { MapIcon } from './Icons';
 interface HeaderProps {
   onCompute?: () => void;
   computeEnabled?: boolean;
+  onExportHydroCAD?: () => void;
+  exportEnabled?: boolean;
 }
-const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
+const Header: React.FC<HeaderProps> = ({
+  onCompute,
+  computeEnabled,
+  onExportHydroCAD,
+  exportEnabled,
+}) => {
   return (
     <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
@@ -14,18 +21,32 @@ const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
-      <button
-        onClick={onCompute}
-        disabled={!computeEnabled}
-        className={
-          'absolute left-1/2 -translate-x-1/2 font-semibold px-4 py-1 rounded ' +
-          (computeEnabled
-            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-        }
-      >
-        Compute
-      </button>
+      <div className="absolute left-1/2 -translate-x-1/2 flex space-x-2">
+        <button
+          onClick={onCompute}
+          disabled={!computeEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (computeEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Compute
+        </button>
+        <button
+          onClick={onExportHydroCAD}
+          disabled={!exportEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (exportEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export Results to HydroCAD
+        </button>
+      </div>
     </header>
   );
 };

--- a/export_templates/hydrocad/example.hyd
+++ b/export_templates/hydrocad/example.hyd
@@ -1,0 +1,1 @@
+Sample HydroCAD template


### PR DESCRIPTION
## Summary
- add folder for export templates with HydroCAD example
- add optional HydroCAD export button to header
- compute export enabled when all compute steps succeed
- stub out export handler in App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883a10f8fa88320b755e8903ebcc8ea