### PR TITLE
Add HydroCAD export button

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
   const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
   const [computeTasks, setComputeTasks] = useState<ComputeTask[] | null>(null);
+  const [computeSuccessful, setComputeSuccessful] = useState<boolean>(false);
 
   const requiredLayers = [
     'Drainage Areas',
@@ -301,6 +302,7 @@ const App: React.FC = () => {
   }, [addLog]);
 
   const runCompute = useCallback(async () => {
+    setComputeSuccessful(false);
     const lod = layers.find(l => l.name === 'LOD');
     const da = layers.find(l => l.name === 'Drainage Areas');
     const wss = layers.find(l => l.name === 'Soil Layer from Web Soil Survey');
@@ -465,6 +467,7 @@ const App: React.FC = () => {
         }
         return finalLayers;
       });
+      setComputeSuccessful(true);
     } catch (err) {
       setComputeTasks(prev => prev.map(t => t.status === 'pending' ? { ...t, status: 'error' } : t));
       addLog('Processing failed', 'error');
@@ -475,9 +478,19 @@ const App: React.FC = () => {
     runCompute();
   }, [runCompute]);
 
+  const handleExportHydroCAD = useCallback(() => {
+    // TODO: implement export functionality
+    addLog('Export to HydroCAD triggered');
+  }, [addLog]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header computeEnabled={computeEnabled} onCompute={handleCompute} />
+      <Header
+        computeEnabled={computeEnabled}
+        onCompute={handleCompute}
+        onExportHydroCAD={handleExportHydroCAD}
+        exportEnabled={computeSuccessful}
+      />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,10 @@ import { MapIcon } from './Icons';
 interface HeaderProps {
   onCompute?: () => void;
   computeEnabled?: boolean;
+  onExportHydroCAD?: () => void;
+  exportEnabled?: boolean;
 }
-const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
+const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled, onExportHydroCAD, exportEnabled }) => {
   return (
     <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
@@ -14,18 +16,32 @@ const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
-      <button
-        onClick={onCompute}
-        disabled={!computeEnabled}
-        className={
-          'absolute left-1/2 -translate-x-1/2 font-semibold px-4 py-1 rounded ' +
-          (computeEnabled
-            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-        }
-      >
-        Compute
-      </button>
+      <div className="flex-1 flex justify-center space-x-4">
+        <button
+          onClick={onCompute}
+          disabled={!computeEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (computeEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Compute
+        </button>
+        <button
+          onClick={onExportHydroCAD}
+          disabled={!exportEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (exportEnabled
+              ? 'bg-teal-600 hover:bg-teal-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export Results to HydroCAD
+        </button>
+      </div>
     </header>
   );
 };

--- a/templates/hydrocad/README.md
+++ b/templates/hydrocad/README.md
@@ -1,0 +1,3 @@
+# HydroCAD Templates
+
+This directory stores example HydroCAD format files for export functionality.

--- a/templates/hydrocad/sample.hcd
+++ b/templates/hydrocad/sample.hcd
@@ -1,0 +1,1 @@
+(Sample HydroCAD data placeholder)


### PR DESCRIPTION
## Summary
- add placeholder directory for HydroCAD templates
- add new Export button in the header
- track compute success and enable the export button only when compute tasks succeed

## Testing
- `npm install`
- `npm run build`
- `node --test tests/intersect.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6883a10f8fa88320b755e8903ebcc8ea