### PR TITLE
Add export modal and land cover descriptions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import InstructionsPage from './components/InstructionsPage';
 import { KNOWN_LAYER_NAMES } from './utils/constants';
 import LayerPreview from './components/LayerPreview';
 import ComputeModal, { ComputeTask } from './components/ComputeModal';
+import ExportModal from './components/ExportModal';
 import { loadLandCoverList, loadCnValues, CnRecord } from './utils/landcover';
 
 const DEFAULT_COLORS: Record<string, string> = {
@@ -40,6 +41,10 @@ const App: React.FC = () => {
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
   const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
   const [computeTasks, setComputeTasks] = useState<ComputeTask[] | null>(null);
+  const [computeSucceeded, setComputeSucceeded] = useState<boolean>(false);
+  const [exportModalOpen, setExportModalOpen] = useState<boolean>(false);
+  const [projectName, setProjectName] = useState<string>('');
+  const [version, setVersion] = useState<string>('V1');
 
   const requiredLayers = [
     'Drainage Areas',
@@ -85,6 +90,16 @@ const App: React.FC = () => {
     const interval = setInterval(fetchBackendLogs, 3000);
     return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (!computeTasks) return;
+    if (computeTasks.every(t => t.status === 'success')) {
+      setComputeSucceeded(true);
+    }
+    if (computeTasks.some(t => t.status === 'error')) {
+      setComputeSucceeded(false);
+    }
+  }, [computeTasks]);
 
   const handleLayerAdded = useCallback((geojson: FeatureCollection, name: string) => {
     setIsLoading(false);
@@ -301,6 +316,7 @@ const App: React.FC = () => {
   }, [addLog]);
 
   const runCompute = useCallback(async () => {
+    setComputeSucceeded(false);
     const lod = layers.find(l => l.name === 'LOD');
     const da = layers.find(l => l.name === 'Drainage Areas');
     const wss = layers.find(l => l.name === 'Soil Layer from Web Soil Survey');
@@ -475,9 +491,100 @@ const App: React.FC = () => {
     runCompute();
   }, [runCompute]);
 
+  const handleExportHydroCAD = useCallback(async () => {
+    const overlay = layers.find(l => l.name === 'Overlay');
+    if (!overlay) {
+      addLog('Overlay layer not found for export', 'error');
+      return;
+    }
+    try {
+      const { area: turfArea } = await import('@turf/turf');
+      const groups: Record<string, { area: number; cn: number; desc: string }[]> = {};
+      overlay.geojson.features.forEach(f => {
+        const da = (f.properties as any)?.DA_NAME || 'DA-?';
+        const cn = (f.properties as any)?.CN ?? 0;
+        const hsg = (f.properties as any)?.HSG || '';
+        const land = (f.properties as any)?.LAND_COVER || '';
+        const desc = `${land}${hsg ? ', HSG ' + hsg : ''}`;
+        const a = turfArea(f as any) * 10.7639; // square feet
+        if (!groups[da]) groups[da] = [];
+        groups[da].push({ area: a, cn, desc });
+      });
+
+      const lines: string[] = [];
+      lines.push('[HydroCAD]');
+      lines.push('FileUnits=English');
+      lines.push('CalcUnits=English');
+      lines.push('InputUnits=English-LowFlow');
+      lines.push('ReportUnits=English-LowFlow');
+      lines.push('LargeAreas=False');
+      lines.push('Source=StormwaterAPP');
+      lines.push(`Name=${projectName || 'Export'}`);
+      lines.push('Path=');
+      lines.push('View=-5.46349942062574 0 15.4634994206257 10');
+      lines.push('GridShow=True');
+      lines.push('GridSnap=True');
+      lines.push('TimeSpan=0 86400');
+      lines.push('TimeInc=36');
+      lines.push('MaxGraph=0');
+      lines.push('RunoffMethod=SCS TR-20');
+      lines.push('ReachMethod=Stor-Ind+Trans');
+      lines.push('PondMethod=Stor-Ind');
+      lines.push('UH=SCS');
+      lines.push('MinTc=300');
+      lines.push('RainEvent=test');
+      lines.push('');
+      lines.push('[EVENT]');
+      lines.push('RainEvent=test');
+      lines.push('StormType=Type II 24-hr');
+      lines.push('StormDepth=0.0833333333333333');
+
+      let yPos = 0;
+      Object.entries(groups).forEach(([daName, polys]) => {
+        lines.push('');
+        lines.push('[NODE]');
+        lines.push(`Number=${daName}`);
+        lines.push('Type=Subcat');
+        lines.push(`Name=${daName}`);
+        lines.push(`XYPos=0 ${yPos}`);
+        yPos += 5;
+        polys.forEach(p => {
+          lines.push('[AREA]');
+          lines.push(`Area=${p.area}`);
+          lines.push(`CN=${p.cn}`);
+          lines.push(`Desc=${p.desc}`);
+        });
+        lines.push('[TC]');
+        lines.push('Method=Direct');
+        lines.push('Tc=300');
+      });
+
+      const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const fname = `${projectName || 'export'}_${version}.hcp`;
+      a.download = fname;
+      a.click();
+      URL.revokeObjectURL(url);
+      addLog('HydroCAD export generated');
+    } catch (err) {
+      addLog('Failed to export HydroCAD', 'error');
+    }
+  }, [layers, addLog, projectName, version]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
-      <Header computeEnabled={computeEnabled} onCompute={handleCompute} />
+      <Header
+        computeEnabled={computeEnabled}
+        onCompute={handleCompute}
+        exportEnabled={computeSucceeded}
+        onOpenExport={() => setExportModalOpen(true)}
+        projectName={projectName}
+        onProjectNameChange={setProjectName}
+        version={version}
+        onVersionChange={setVersion}
+      />
       <div className="flex flex-1 overflow-hidden">
         <aside className="w-72 md:w-96 2xl:w-[32rem] bg-gray-800 p-4 md:p-6 flex flex-col space-y-6 overflow-y-auto shadow-lg border-r border-gray-700">
           <FileUpload
@@ -534,6 +641,13 @@ const App: React.FC = () => {
       </div>
       {computeTasks && (
         <ComputeModal tasks={computeTasks} onClose={() => setComputeTasks(null)} />
+      )}
+      {exportModalOpen && (
+        <ExportModal
+          onClose={() => setExportModalOpen(false)}
+          onExportHydroCAD={handleExportHydroCAD}
+          exportEnabled={computeSucceeded}
+        />
       )}
     </div>
   );

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ python scripts/update_soil_hsg_map.py --areas CA630 CA649
 The default styles target 1080p displays but scale gracefully up to 4K
 monitors. Base font sizes and sidebar widths increase on very large
 screens to keep the interface readable while remaining fully responsive.
+
+## Exporting results
+
+After computing results, click **Export** in the header to open the export modal. Provide a project name and select a version (V1–V10) to determine the filename. The modal currently supports exporting to HydroCAD using templates from `export_templates/hydrocad/`.

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface ExportModalProps {
+  onClose: () => void;
+  onExportHydroCAD: () => void;
+  exportEnabled: boolean;
+}
+
+const ExportModal: React.FC<ExportModalProps> = ({ onClose, onExportHydroCAD, exportEnabled }) => (
+  <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
+    <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-white">Export</h2>
+        <button className="text-gray-400 hover:text-white" onClick={onClose}>✕</button>
+      </div>
+      <button
+        onClick={onExportHydroCAD}
+        disabled={!exportEnabled}
+        className={
+          'w-full px-4 py-2 rounded font-semibold ' +
+          (exportEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        Export Results to HydroCAD
+      </button>
+    </div>
+  </div>
+);
+
+export default ExportModal;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,23 @@ import { MapIcon } from './Icons';
 interface HeaderProps {
   onCompute?: () => void;
   computeEnabled?: boolean;
+  onOpenExport?: () => void;
+  exportEnabled?: boolean;
+  projectName: string;
+  onProjectNameChange: (v: string) => void;
+  version: string;
+  onVersionChange: (v: string) => void;
 }
-const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
+const Header: React.FC<HeaderProps> = ({
+  onCompute,
+  computeEnabled,
+  onOpenExport,
+  exportEnabled,
+  projectName,
+  onProjectNameChange,
+  version,
+  onVersionChange,
+}) => {
   return (
     <header className="relative bg-gray-800/50 backdrop-blur-sm border-b border-gray-700 shadow-md p-4 flex items-center space-x-4 z-10">
       <MapIcon className="w-8 h-8 text-cyan-400" />
@@ -14,18 +29,50 @@ const Header: React.FC<HeaderProps> = ({ onCompute, computeEnabled }) => {
         <h1 className="text-xl font-bold text-white">Shapefile Viewer Pro</h1>
         <p className="text-sm text-gray-400">Upload and visualize your geographic data</p>
       </div>
-      <button
-        onClick={onCompute}
-        disabled={!computeEnabled}
-        className={
-          'absolute left-1/2 -translate-x-1/2 font-semibold px-4 py-1 rounded ' +
-          (computeEnabled
-            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-        }
-      >
-        Compute
-      </button>
+      <div className="absolute left-1/2 -translate-x-1/2 flex space-x-2">
+        <button
+          onClick={onCompute}
+          disabled={!computeEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (computeEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Compute
+        </button>
+        <button
+          onClick={onOpenExport}
+          disabled={!exportEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (exportEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export
+        </button>
+      </div>
+      <div className="absolute right-4 flex items-center space-x-2">
+        <input
+          type="text"
+          className="bg-gray-700 text-white rounded px-2 py-1 text-sm"
+          placeholder="Project Name"
+          value={projectName}
+          onChange={e => onProjectNameChange(e.target.value)}
+        />
+        <select
+          className="bg-gray-700 text-white rounded px-2 py-1 text-sm"
+          value={version}
+          onChange={e => onVersionChange(e.target.value)}
+        >
+          {Array.from({ length: 10 }, (_, i) => (
+            <option key={i} value={`V${i + 1}`}>{`V${i + 1}`}</option>
+          ))}
+        </select>
+      </div>
     </header>
   );
 };

--- a/export_templates/README.md
+++ b/export_templates/README.md
@@ -1,0 +1,3 @@
+This directory holds example templates for exporting results to various software formats.
+
+`hydrocad` contains a `template.hyd` file showing the expected format for HydroCAD exports.

--- a/export_templates/hydrocad/example.txt
+++ b/export_templates/hydrocad/example.txt
@@ -1,0 +1,1 @@
+Placeholder for HydroCAD export template.

--- a/export_templates/hydrocad/template.hyd
+++ b/export_templates/hydrocad/template.hyd
@@ -1,0 +1,38 @@
+[HydroCAD]
+FileUnits=English
+CalcUnits=English
+InputUnits=English-LowFlow
+ReportUnits=English-LowFlow
+LargeAreas=False
+Source=HydroCAD® 10.20-6a  s/n 07447  © 2024 HydroCAD Software Solutions LLC
+Name=test2
+Path=C:\Users\sacevedo2\OneDrive - GHD\Desktop\STORMWATER APP\Export\HydroCAD\
+View=-5.46349942062574 0 15.4634994206257 10
+GridShow=True
+GridSnap=True
+TimeSpan=0 86400
+TimeInc=36
+MaxGraph=0
+RunoffMethod=SCS TR-20
+ReachMethod=Stor-Ind+Trans
+PondMethod=Stor-Ind
+UH=SCS
+MinTc=300
+RainEvent=test
+
+[EVENT]
+RainEvent=test
+StormType=Type II 24-hr
+StormDepth=0.0833333333333333
+
+[NODE]
+Number=1S
+Type=Subcat
+Name=(new Subcat)
+XYPos=2 7
+[AREA]
+Area=1
+CN=99
+[TC]
+Method=Direct
+Tc=300


### PR DESCRIPTION
## Summary
- create ExportModal to offer HydroCAD export via a popup
- allow selecting versions V1-V10 in header
- enable opening export modal with new 'Export' button
- include land cover description in HydroCAD export file
- document export modal in README

## Testing
- `npm install`
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6883a10f8fa88320b755e8903ebcc8ea