### PR TITLE
Add georeferenced PDF overlay

### DIFF
--- a/components/PdfOverlay.tsx
+++ b/components/PdfOverlay.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+import { useMap, Pane } from 'react-leaflet';
+import L from 'leaflet';
+import { RotatedImageOverlay } from '../utils/RotatedImageOverlay';
+
+interface ControlPoint {
+  img: { x: number; y: number };
+  latlng: L.LatLngExpression;
+}
+
+interface PdfOverlayProps {
+  url: string;
+  points: [ControlPoint, ControlPoint] | null;
+  zIndex?: number;
+  onClick?: (imgX: number, imgY: number, event: L.LeafletMouseEvent) => void;
+}
+
+const PdfOverlay: React.FC<PdfOverlayProps> = ({ url, points, zIndex = 350, onClick }) => {
+  const map = useMap();
+  const overlayRef = useRef<RotatedImageOverlay | null>(null);
+
+  useEffect(() => {
+    if (!map) return;
+    const overlay = new RotatedImageOverlay(url, { opacity: 1, pane: 'pdfPane' });
+    overlayRef.current = overlay;
+    overlay.addTo(map);
+    const img = overlay.getElement();
+    if (onClick) {
+      img.style.pointerEvents = 'auto';
+      img.addEventListener('click', (e: any) => {
+        const rect = img.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        onClick(x, y, map.mouseEventToLatLng(e));
+      });
+    } else {
+      img.style.pointerEvents = 'none';
+    }
+    return () => {
+      overlay.remove();
+    };
+  }, [map, url, onClick]);
+
+  useEffect(() => {
+    if (!overlayRef.current) return;
+    if (points) {
+      const [p1, p2] = points;
+      overlayRef.current.setControlPoints(L.point(p1.img), L.point(p2.img), p1.latlng, p2.latlng);
+    }
+  }, [points]);
+
+  return <Pane name="pdfPane" style={{ zIndex }} />;
+};
+
+export default PdfOverlay;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
+        "pdfjs-dist": "^5.3.93",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
@@ -711,6 +712,191 @@
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz",
       "integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.74.tgz",
+      "integrity": "sha512-pOIyzuS+5Bz1vAhD7tdhaw5/936mMJZUn4aVajojUdjYOGSWmfpDYSgt0nQLZPZVN5GLgWgutqXPOi7Jsm3k+Q==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.74",
+        "@napi-rs/canvas-darwin-arm64": "0.1.74",
+        "@napi-rs/canvas-darwin-x64": "0.1.74",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.74",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.74",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.74",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.74",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.74"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.74.tgz",
+      "integrity": "sha512-aq5ode+9Z/ZR0H485dI2jdRdttg/hl9Ob+iPCt0nj+QFiirpxDrbUHKeTZWQWEtkWyC7vI5R2dMTbDINBfl9eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.74.tgz",
+      "integrity": "sha512-eO5Miz+ef1dEQyUMWDdcbAb1Wr7yMyxD9/CL9d4frQxO4pTTaCiMBUWup8XDPLr/g7XkSkGCZLP47xiXiyXSpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.74.tgz",
+      "integrity": "sha512-0EkO0IFkps7C3JpKC7lbM3IL+QDUYeUKagHLDbUry4PeQTghxp6JcgccpmU32ZbpFZgPnm7o0tTJO0J1d8S2rA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.74.tgz",
+      "integrity": "sha512-qAVJEN2JqGayEI1kSpJy1Xr6ZmCFV9QhRyV35yWsS7e9X1jm+T4DAlCxI4PlKIlqVSzYMYhKrxchST20XBSzHg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.74.tgz",
+      "integrity": "sha512-lOnop22qy6MYxI94GGunMMjo6D80I//2W/6pqKUfwXaDQtOfvHsTcVVzDu5cFXUTNrb9ZRfMCeol5YEd+9FJvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.74.tgz",
+      "integrity": "sha512-tfFqLHGtSEabBigOnPUfZviSTGmW2xHv5tYZYPBWmgGiTkoNJ7lEWFUxHjwvV5HXGqLs8ok/O7g1enSpxO6lmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.74.tgz",
+      "integrity": "sha512-j6H9dHTMtr1y3tu/zGm1ythYIL9vTl4EEv9f6CMx0n3Zn2M+OruUUwh9ylCj4afzSNEK9T8cr6zMnmTPzkpBvQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.74.tgz",
+      "integrity": "sha512-73DIV4E7Y9CpIJuUXVl9H6+MEQXyRy4VJQoUGA1tOlcKQiStxqhq6UErL4decI28NxjyQXBhtYZKj5q8AJEuOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.74.tgz",
+      "integrity": "sha512-FgDMEFdGIJT3I2xejflRJ82/ZgDphyirS43RgtoLaIXI6zihLiZcQ7rczpqeWgAwlJNjR0He2EustsKe1SkUOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.74.tgz",
+      "integrity": "sha512-x6bhwlhn0wU7dfiP46mt5Bi6PowSUH4CJ4PTzGj58LRQ1HVasEIJgoMx7MLC48F738eJpzbfg3WR/D8+e9CeTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
@@ -3995,6 +4181,18 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.3.93",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.3.93.tgz",
+      "integrity": "sha512-w3fQKVL1oGn8FRyx5JUG5tnbblggDqyx2XzA5brsJ5hSuS+I0NdnJANhmeWKLjotdbPQucLBug5t0MeWr0AAdg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.71"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
+    "pdfjs-dist": "^5.3.93",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",

--- a/utils/RotatedImageOverlay.ts
+++ b/utils/RotatedImageOverlay.ts
@@ -1,0 +1,61 @@
+import L from 'leaflet';
+
+export class RotatedImageOverlay extends L.ImageOverlay {
+  private _imgP1: L.Point = L.point(0, 0);
+  private _imgP2: L.Point = L.point(1, 0);
+  private _mapP1: L.LatLng = L.latLng(0, 0);
+  private _mapP2: L.LatLng = L.latLng(0, 0);
+
+  constructor(url: string, options?: L.ImageOverlayOptions) {
+    super(url, [[0,0],[0,0]], options);
+  }
+
+  setControlPoints(img1: L.PointExpression, img2: L.PointExpression, ll1: L.LatLngExpression, ll2: L.LatLngExpression) {
+    this._imgP1 = L.point(img1);
+    this._imgP2 = L.point(img2);
+    this._mapP1 = L.latLng(ll1);
+    this._mapP2 = L.latLng(ll2);
+    this._reset();
+  }
+
+  onAdd(map: L.Map) {
+    super.onAdd(map);
+    map.on('zoom viewreset move', this._reset, this);
+    (this.getElement() as HTMLElement).style.transformOrigin = '0 0';
+    if (!this.getElement().complete) {
+      this.getElement().addEventListener('load', () => this._reset());
+    }
+  }
+
+  onRemove(map: L.Map) {
+    map.off('zoom viewreset move', this._reset, this);
+    super.onRemove(map);
+  }
+
+  _reset() {
+    if (!this._map) return;
+    const map = this._map;
+    const p1 = map.latLngToLayerPoint(this._mapP1);
+    const p2 = map.latLngToLayerPoint(this._mapP2);
+    const dxImg = this._imgP2.x - this._imgP1.x;
+    const dyImg = this._imgP2.y - this._imgP1.y;
+    const dxMap = p2.x - p1.x;
+    const dyMap = p2.y - p1.y;
+    const scale = Math.sqrt(dxMap*dxMap + dyMap*dyMap) / Math.sqrt(dxImg*dxImg + dyImg*dyImg || 1);
+    const angle = Math.atan2(dyMap, dxMap) - Math.atan2(dyImg, dxImg);
+    const cos = Math.cos(angle) * scale;
+    const sin = Math.sin(angle) * scale;
+    const a = cos;
+    const b = sin;
+    const c = -sin;
+    const d = cos;
+    const e = p1.x - a*this._imgP1.x - c*this._imgP1.y;
+    const f = p1.y - b*this._imgP1.x - d*this._imgP1.y;
+    const el = this.getElement() as HTMLElement;
+    el.style.transform = `matrix(${a},${b},${c},${d},${e},${f})`;
+  }
+}
+
+export function rotatedImageOverlay(url: string, options?: L.ImageOverlayOptions) {
+  return new RotatedImageOverlay(url, options);
+}


### PR DESCRIPTION
## Summary
- allow adding a PDF background layer
- compute transform from two control points
- render PDF above imagery but below vector layers

## Testing
- `npm run build`
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6883ca13f3e08320a4944c7c4d4d5a08