### PR TITLE
feat: add shapefile export option

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 interface ExportModalProps {
   onExportHydroCAD: () => void;
+  onExportShapefiles: () => void;
   onClose: () => void;
   exportEnabled?: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onClose, exportEnabled }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportShapefiles, onClose, exportEnabled }) => {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
       <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
@@ -23,6 +24,16 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onClose, ex
           }
         >
           Export to HydroCAD
+        </button>
+        <button
+          onClick={onExportShapefiles}
+          disabled={!exportEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export processed shapefiles
         </button>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
         "react-leaflet-google-layer": "^4.0.0",
+        "shp-write": "^0.3.2",
         "shpjs": "^6.1.0"
       },
       "devDependencies": {
@@ -3290,6 +3291,15 @@
       "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/dbf": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/dbf/-/dbf-0.1.4.tgz",
+      "integrity": "sha512-7tQ8w5NB74PL1f0Z/NQ6Y+URjBFhtEsFxzEQSzot2+VpLwWfrNnxFVhzWm6dJyEtFq0WkYWcGEMDf39fy8JFaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jdataview": "~2.5.0"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3775,6 +3785,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/jdataview": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jdataview/-/jdataview-2.5.0.tgz",
+      "integrity": "sha512-ZJop3D5nyDcWPBPv4NPnhCvx3HgQNsCXMfw8gpNKY16BobgxmVF+kJ08aHuqk6bJQVeL2mkf6nDCcZPMompalw=="
     },
     "node_modules/jsts": {
       "version": "2.7.1",
@@ -4379,6 +4394,32 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shp-write": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/shp-write/-/shp-write-0.3.2.tgz",
+      "integrity": "sha512-RNmfm+qzIwgwGMiV21lCxfEAtgP/owAd+sHLr6Qu+aDR1bbrCZ42H89nA9FQWUqfL+WHJy3n8+cTZxJrL/ZKWA==",
+      "deprecated": "This package has moved under the @mapbox organization, and can be found here: https://www.npmjs.com/package/@mapbox/shp-write",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dbf": "0.1.4",
+        "jszip": "2.5.0"
+      }
+    },
+    "node_modules/shp-write/node_modules/jszip": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
+      "integrity": "sha512-IRoyf8JSYY3nx+uyh5xPc0qdy8pUDTp2UkHOWYNF/IO/3D8nx7899UlSAjD8rf8wUgOmm0lACWx/GbW3EaxIXQ==",
+      "license": "MIT or GPLv3",
+      "dependencies": {
+        "pako": "~0.2.5"
+      }
+    },
+    "node_modules/shp-write/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/shpjs": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
     "react-leaflet-google-layer": "^4.0.0",
+    "shp-write": "^0.3.2",
     "shpjs": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add button to export processed shapefiles from export modal
- implement processed shapefile zipping and download
- include shp-write dependency for shapefile creation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a6b20d9c83208662a438d3f62fd9