### PR TITLE
Add shapefile export option

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -73,6 +73,7 @@ const App: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    if (!import.meta.env.DEV) return;
     const fetchBackendLogs = async () => {
       try {
         const res = await fetch('/api/logs');
@@ -537,6 +538,42 @@ const App: React.FC = () => {
     });
   }, [addLog, layers, projectName, projectVersion]);
 
+  const handleExportShapefiles = useCallback(async () => {
+    const processedLayers = layers.filter(l => l.category === 'Process');
+    if (processedLayers.length === 0) {
+      addLog('No processed layers to export', 'error');
+      return;
+    }
+    const JSZip = (await import('jszip')).default;
+    const shpwrite = (await import('@mapbox/shp-write')).default;
+    const zip = new JSZip();
+
+    for (const layer of processedLayers) {
+      const layerZipBuffer = shpwrite.zip(layer.geojson);
+      const layerZip = await JSZip.loadAsync(layerZipBuffer);
+      const folderName = layer.name.replace(/[^a-z0-9_\-]/gi, '_');
+      const folder = zip.folder(folderName);
+      if (!folder) continue;
+      await Promise.all(
+        Object.keys(layerZip.files).map(async filename => {
+          const content = await layerZip.files[filename].async('arraybuffer');
+          folder.file(filename, content);
+        })
+      );
+    }
+
+    const blob = await zip.generateAsync({ type: 'blob' });
+    const filename = `${(projectName || 'project')}_${projectVersion}_shapefiles.zip`;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    addLog('Processed shapefiles exported');
+    setExportModalOpen(false);
+  }, [addLog, layers, projectName, projectVersion]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header
@@ -609,6 +646,7 @@ const App: React.FC = () => {
       {exportModalOpen && (
         <ExportModal
           onExportHydroCAD={handleExportHydroCAD}
+          onExportShapefiles={handleExportShapefiles}
           onClose={() => setExportModalOpen(false)}
           exportEnabled={computeSucceeded}
         />

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 interface ExportModalProps {
   onExportHydroCAD: () => void;
+  onExportShapefiles: () => void;
   onClose: () => void;
   exportEnabled?: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onClose, exportEnabled }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportShapefiles, onClose, exportEnabled }) => {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
       <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
@@ -23,6 +24,16 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onClose, ex
           }
         >
           Export to HydroCAD
+        </button>
+        <button
+          onClick={onExportShapefiles}
+          disabled={!exportEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export processed shapefiles
         </button>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@geoman-io/leaflet-geoman-free": "^2.18.3",
+        "@mapbox/shp-write": "^0.4.3",
         "@turf/turf": "^7.2.0",
         "@types/leaflet-draw": "^1.0.12",
         "express": "^4.19.2",
@@ -711,6 +712,26 @@
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz",
       "integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@mapbox/shp-write": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/shp-write/-/shp-write-0.4.3.tgz",
+      "integrity": "sha512-mkKIHgtnytyP+cXfk+joYeWwk+SODZ7COQusTcO1rZQVUn68MjzW2F74XMsNIusabnwj5aoKNI8B3mYq9KZ9AQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dbf": "0.2.0",
+        "file-saver": "2.0.5",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/@mapbox/shp-write/node_modules/dbf": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dbf/-/dbf-0.2.0.tgz",
+      "integrity": "sha512-JMeGCJzFcVGsfnkIuqrnuiSkJpTu6c4AKJg3LXDnfW7zU/2PSIue3KG4fz9c+/mmlDzT+rVCwyEHzzhxzrzPiA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jdataview": "~2.5.0"
+      }
     },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
@@ -3506,6 +3527,12 @@
         }
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -3775,6 +3802,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/jdataview": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jdataview/-/jdataview-2.5.0.tgz",
+      "integrity": "sha512-ZJop3D5nyDcWPBPv4NPnhCvx3HgQNsCXMfw8gpNKY16BobgxmVF+kJ08aHuqk6bJQVeL2mkf6nDCcZPMompalw=="
     },
     "node_modules/jsts": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
     "react-leaflet-google-layer": "^4.0.0",
+    "@mapbox/shp-write": "^0.4.3",
     "shpjs": "^6.1.0"
   },
   "devDependencies": {

--- a/shp-write.d.ts
+++ b/shp-write.d.ts
@@ -1,0 +1,1 @@
+declare module '@mapbox/shp-write';


### PR DESCRIPTION
## Summary
- add `Export processed shapefiles` option alongside HydroCAD export
- bundle processed layers into per-layer shapefile folders within a zip
- switch to `@mapbox/shp-write` and guard backend log polling for stability

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b28c40448320bebd183a287dc84b