### PR TITLE
Fix placeholder ellipses and swap to lucide-react icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,10 +36,17 @@ const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [zoomToLayer, setZoomToLayer] = useState<{ id: string; ts: number } | null>(null);
-  const [editingTarget, setEditingTarget] = useState<{ layerId: string | null; featureIndex: number | null }>({ layerId: null, featureIndex: null });
+  const [editingTarget, setEditingTarget] = useState<{
+    layerId: string | null;
+    featureIndex: number | null;
+  }>({ layerId: null, featureIndex: null });
   const [editingBackup, setEditingBackup] = useState<{ layerId: string; geojson: FeatureCollection } | null>(null);
   const [landCoverOptions, setLandCoverOptions] = useState<string[]>([]);
-  const [previewLayer, setPreviewLayer] = useState<{ data: FeatureCollection; fileName: string; detectedName: string } | null>(null);
+  const [previewLayer, setPreviewLayer] = useState<{
+    data: FeatureCollection;
+    fileName: string;
+    detectedName: string;
+  } | null>(null);
   const [computeTasks, setComputeTasks] = useState<ComputeTask[] | null>(null);
   const [computeSucceeded, setComputeSucceeded] = useState<boolean>(false);
   const [projectName, setProjectName] = useState<string>('');

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -42,7 +42,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
     }
 
     onLoading();
-    onLog(`Processing ${file.name}...`);
+    onLog(`Processing ${file.name}`);
 
     try {
       let buffer = await file.arrayBuffer();
@@ -172,7 +172,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ onLayerAdded, onLoading, onErro
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
-              <p className="mt-4 text-sm text-gray-400">Processing file...</p>
+              <p className="mt-4 text-sm text-gray-400">Processing file</p>
             </>
           ) : (
             <>

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,74 +1,28 @@
 import React from 'react';
+import {
+  Map as MapIconBase,
+  Upload as UploadIconBase,
+  XCircle as XCircleIconBase,
+  Info as InfoIconBase,
+  Trash2 as TrashIconBase,
+  Edit as EditIconBase,
+  Lock as LockClosedIconBase,
+  Eye as EyeIconBase,
+  EyeOff as EyeOffIconBase,
+  CheckCircle as CheckCircleIconBase,
+  Search as SearchIconBase,
+} from 'lucide-react';
 
-type IconProps = {
-  className?: string;
-};
-
-export const MapIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l6-3a1 1 0 00.553-1.894L15 9m0 11V9m0 0L9 7" />
-  </svg>
-);
-
-export const UploadIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-  </svg>
-);
-
-export const CheckCircleIcon: React.FC<IconProps> = ({ className }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-);
-
-export const XCircleIcon: React.FC<IconProps> = ({ className }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-);
-
-export const InfoIcon: React.FC<IconProps> = ({ className }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-);
-
-export const TrashIcon: React.FC<IconProps> = ({ className }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-    </svg>
-);
-
-export const EditIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5h2m-1 0v9m-6.707.707l-.707.707a1 1 0 101.414 1.414l.707-.707M16.414 4.586a2 2 0 112.828 2.828l-10 10-4 1 1-4 10-10z" />
-  </svg>
-);
-
-export const SearchIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
-  </svg>
-);
-
-export const LockClosedIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M16 10V7a4 4 0 10-8 0v3M5 10h14v10H5V10z" />
-  </svg>
-);
-
-export const EyeIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-  </svg>
-);
-
-export const EyeOffIcon: React.FC<IconProps> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A9.956 9.956 0 0112 19c-4.478 0-8.269-2.943-9.543-7a9.974 9.974 0 012.758-4.393m3.738-2.37A9.956 9.956 0 0112 5c4.478 0 8.269 2.943 9.543 7a9.965 9.965 0 01-4.293 5.73M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18" />
-  </svg>
-);
+type IconProps = { className?: string };
+export const MapIcon: React.FC<IconProps> = ({ className }) => <MapIconBase className={className} />;
+export const UploadIcon: React.FC<IconProps> = ({ className }) => <UploadIconBase className={className} />;
+export const XCircleIcon: React.FC<IconProps> = ({ className }) => <XCircleIconBase className={className} />;
+export const InfoIcon: React.FC<IconProps> = ({ className }) => <InfoIconBase className={className} />;
+export const TrashIcon: React.FC<IconProps> = ({ className }) => <TrashIconBase className={className} />;
+export const EditIcon: React.FC<IconProps> = ({ className }) => <EditIconBase className={className} />;
+export const LockClosedIcon: React.FC<IconProps> = ({ className }) => <LockClosedIconBase className={className} />;
+export const EyeIcon: React.FC<IconProps> = ({ className }) => <EyeIconBase className={className} />;
+export const EyeOffIcon: React.FC<IconProps> = ({ className }) => <EyeOffIconBase className={className} />;
+export const CheckCircleIcon: React.FC<IconProps> = ({ className }) => <CheckCircleIconBase className={className} />;
+export const SearchIcon: React.FC<IconProps> = ({ className }) => <SearchIconBase className={className} />;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
+        "lucide-react": "^0.541.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
@@ -3861,6 +3862,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.541.0.tgz",
+      "integrity": "sha512-s0Vircsu5WaGv2KoJZ5+SoxiAJ3UXV5KqEM3eIFDHaHkcLIFdIWgXtZ412+Gh02UsdS7Was+jvEpBvPCWQISlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/marchingsquares": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",
+    "lucide-react": "^0.541.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",


### PR DESCRIPTION
## Summary
- Replace custom SVG icons with lucide-react components
- Normalize App state definitions and remove placeholder ellipses in file upload messages
- Add lucide-react dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac7bb907f88320b58abad596de94c9