### PR TITLE
Fix landcover utility and turf intersect invocation

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,8 +16,6 @@ const logs = [];
 const featureCollectionLocal = (features) => ({ type: 'FeatureCollection', features });
 const toFeature = (poly) =>
   poly.type === 'Feature' ? poly : { type: 'Feature', properties: {}, geometry: poly };
-const intersect = (poly1, poly2) =>
-  turfIntersect(featureCollectionLocal([toFeature(poly1), toFeature(poly2)]));
 function addLog(message, type = 'info') {
   const entry = { message, type, source: 'backend', timestamp: Date.now() };
   logs.push(entry);
@@ -80,7 +78,9 @@ app.post('/api/intersect', (req, res) => {
   }
 
   try {
-    const result = intersect(poly1, poly2);
+    const result = turfIntersect(
+      featureCollectionLocal([toFeature(poly1), toFeature(poly2)])
+    );
     addLog('Intersection calculated');
     res.json(result || null);
   } catch (err) {

--- a/utils/landcover.ts
+++ b/utils/landcover.ts
@@ -1,12 +1,20 @@
+// utils/landcover.ts
+export type CnRecord = {
+  LandCover: string;
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+};
+
 export async function loadLandCoverList(): Promise<string[]> {
   const sources = ['/api/cn-values', '/data/SCS_CN_VALUES.json'];
   for (const url of sources) {
     try {
       const res = await fetch(url);
       if (res.ok) {
-        const data = await res.json();
-        const list = Array.from(new Set((data as any[]).map(d => d.LandCover).filter(Boolean)));
-        return list;
+        const data = (await res.json()) as any[];
+        return Array.from(new Set(data.map(d => d?.LandCover).filter(Boolean)));
       }
       console.warn(`CN values request to ${url} failed with status ${res.status}`);
     } catch (err) {
@@ -14,14 +22,6 @@ export async function loadLandCoverList(): Promise<string[]> {
     }
   }
   return [];
-}
-
-export interface CnRecord {
-  LandCover: string;
-  A: number;
-  B: number;
-  C: number;
-  D: number;
 }
 
 export async function loadCnValues(): Promise<CnRecord[]> {


### PR DESCRIPTION
## Summary
- restore complete landcover utilities with CN record type and helpers
- call turfIntersect directly when computing polygon intersections

## Testing
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac88aea49c832088c76e267a13b144