### PR TITLE
Auto-assign Land Cover values and fit map to layer extent

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -135,10 +135,15 @@ const App: React.FC = () => {
     if (name === 'Land Cover') {
       geojson = {
         ...geojson,
-        features: geojson.features.map(f => ({
-          ...f,
-          properties: { ...(f.properties || {}), LAND_COVER: f.properties?.LAND_COVER ?? '' }
-        }))
+        features: geojson.features.map(f => {
+          const raw = (f.properties as any)?.LandCover ?? (f.properties as any)?.LAND_COVER ?? '';
+          const match =
+            landCoverOptions.find(opt => opt.toLowerCase() === String(raw).toLowerCase()) ?? '';
+          return {
+            ...f,
+            properties: { ...(f.properties || {}), LAND_COVER: match },
+          };
+        }),
       } as FeatureCollection;
     }
 
@@ -171,7 +176,7 @@ const App: React.FC = () => {
       addLog(`Loaded layer ${name}${editable ? '' : ' (view only)'}`);
       return [...prevLayers, newLayer];
     });
-  }, [addLog]);
+  }, [addLog, landCoverOptions]);
 
   const handlePreviewReady = useCallback((geojson: FeatureCollection, fileName: string, detectedName: string) => {
     setIsLoading(false);

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -285,7 +285,7 @@ const ManagedGeoJsonLayer = ({
     if (isLastAdded && geoJsonRef.current) {
       const bounds = geoJsonRef.current.getBounds();
       if (bounds.isValid()) {
-        map.flyToBounds(bounds, { padding: [50, 50], maxZoom: 16 });
+        map.fitBounds(bounds);
       }
     }
   }, [data, isLastAdded, map]);
@@ -310,7 +310,7 @@ const ZoomToLayerHandler = ({ layers, target }: { layers: LayerData[]; target: {
     if (layer) {
       const bounds = L.geoJSON(layer.geojson).getBounds();
       if (bounds.isValid()) {
-        map.flyToBounds(bounds, { padding: [50, 50], maxZoom: 16 });
+        map.fitBounds(bounds);
       }
     }
   }, [target, layers, map]);


### PR DESCRIPTION
## Summary
- Auto-fill Land Cover features from the `LandCover` attribute when it matches known options
- Fit map view to the extent of Land Cover layers for a tighter zoom

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac9282c3708320964bd622961eac72