### PR TITLE
feat: add SWMM export option

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -552,6 +552,36 @@ const App: React.FC = () => {
     });
   }, [addLog, layers, projectName, projectVersion]);
 
+  const handleExportSWMM = useCallback(async () => {
+    const templateFiles = [
+      'SWMM_TEMPLATE.chi',
+      'SWMM_TEMPLATE.db',
+      'SWMM_TEMPLATE.ini',
+      'SWMM_TEMPLATE.inp',
+      'SWMM_TEMPLATE.thm',
+    ];
+    const JSZip = (await import('jszip')).default;
+    const zip = new JSZip();
+
+    for (const file of templateFiles) {
+      const url = new URL(`./export_templates/swmm/${file}`, import.meta.url);
+      const res = await fetch(url);
+      const content = await res.arrayBuffer();
+      zip.file(file, content);
+    }
+
+    const blob = await zip.generateAsync({ type: 'blob' });
+    const filename = `${(projectName || 'project')}_${projectVersion}_swmm.zip`;
+    const dlUrl = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = dlUrl;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(dlUrl);
+    addLog('SWMM template exported');
+    setExportModalOpen(false);
+  }, [addLog, projectName, projectVersion]);
+
   const handleExportShapefiles = useCallback(async () => {
     const processedLayers = layers.filter(l => l.category === 'Process');
     if (processedLayers.length === 0) {
@@ -667,6 +697,7 @@ const App: React.FC = () => {
       {exportModalOpen && (
         <ExportModal
           onExportHydroCAD={handleExportHydroCAD}
+          onExportSWMM={handleExportSWMM}
           onExportShapefiles={handleExportShapefiles}
           onClose={() => setExportModalOpen(false)}
           exportEnabled={computeSucceeded}

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 
 interface ExportModalProps {
   onExportHydroCAD: () => void;
+  onExportSWMM: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
   exportEnabled?: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportShapefiles, onClose, exportEnabled }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled }) => {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
       <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
@@ -24,6 +25,16 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSha
           }
         >
           Export to HydroCAD
+        </button>
+        <button
+          onClick={onExportSWMM}
+          disabled={!exportEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export to SWMM
         </button>
         <button
           onClick={onExportShapefiles}


### PR DESCRIPTION
## Summary
- add "Export to SWMM" option in export modal
- zip SWMM template files and download

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba8a36c88320a593686f005ba3a3