### PR TITLE
feat: add SWMM export option

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 
 interface ExportModalProps {
   onExportHydroCAD: () => void;
+  onExportSWMM: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
   exportEnabled?: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportShapefiles, onClose, exportEnabled }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled }) => {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
       <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
@@ -24,6 +25,16 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSha
           }
         >
           Export to HydroCAD
+        </button>
+        <button
+          onClick={onExportSWMM}
+          disabled={!exportEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export to SWMM
         </button>
         <button
           onClick={onExportShapefiles}


### PR DESCRIPTION
## Summary
- add Export to SWMM button in export modal
- implement SWMM export that copies template files, zips them, and triggers download

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5bdd31ae08320a9fdee741583e8ab