### PR TITLE
feat: export SWMM with drainage areas

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -553,31 +553,46 @@ const App: React.FC = () => {
   }, [addLog, layers, projectName, projectVersion]);
 
   const handleExportSWMM = useCallback(async () => {
-    const files = import.meta.glob('./export_templates/swmm/**', { as: 'raw' });
-    const working: Record<string, string> = {};
-    await Promise.all(
-      Object.entries(files).map(async ([path, loader]) => {
-        const content = await loader();
-        const filename = path.replace(/^.*\/swmm\//, '');
-        working[filename] = content as string;
-      })
-    );
-    const JSZip = (await import('jszip')).default;
-    const zip = new JSZip();
-    Object.entries(working).forEach(([name, content]) => {
-      zip.file(name, content);
-    });
-    const blob = await zip.generateAsync({ type: 'blob' });
-    const filename = `${(projectName || 'project')}_${projectVersion}_swmm.zip`;
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-    addLog('SWMM template exported');
-    setExportModalOpen(false);
-  }, [addLog, projectName, projectVersion]);
+    const daLayer =
+      layers.find(l => l.name === 'Drainage Area in LOD') ||
+      layers.find(l => l.name === 'Drainage Areas');
+    if (!daLayer) {
+      addLog('No drainage areas to export', 'error');
+      return;
+    }
+
+    const payload = {
+      defaults: {},
+      subcatchments: daLayer.geojson.features.map((f, i) => ({
+        name: (f.properties as any)?.DA_NAME || `S${i + 1}`,
+        geometry: f.geometry,
+      })),
+    };
+
+    try {
+      const resp = await fetch('/api/export-swmm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!resp.ok) {
+        addLog('Failed to export SWMM', 'error');
+        return;
+      }
+      const blob = await resp.blob();
+      const filename = `${(projectName || 'project')}_${projectVersion}.inp`;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      addLog('SWMM file exported');
+      setExportModalOpen(false);
+    } catch (e) {
+      addLog('Failed to export SWMM', 'error');
+    }
+  }, [addLog, layers, projectName, projectVersion]);
 
   const handleExportShapefiles = useCallback(async () => {
     const processedLayers = layers.filter(l => l.category === 'Process');


### PR DESCRIPTION
## Summary
- add `/api/export-swmm` endpoint that builds a SWMM .inp from user polygons
- export Drainage Areas as SWMM subcatchments from the frontend

## Testing
- ❌ `npm test` (Missing script: "test")
- ❌ `npx tsc --noEmit` (Type errors in existing files)
- ✅ `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5c5c85328832093850c2d1886c5bb