### PR TITLE
Include drainage area polygons in SWMM export

### DIFF
--- a/raw.d.ts
+++ b/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- populate SWMM export with subcatchment polygons from the overlay layer
- generate subcatchment, subarea and infiltration records in exported `.inp`
- add declaration for `?raw` module imports
- merge overlay features sharing the same drainage area ID so each subcatchment is exported once with a unified polygon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c938d43c832095cd1d7a90d76be1