### PR TITLE
Sanitize SWMM polygon IDs and validate geometry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -562,26 +562,49 @@ const App: React.FC = () => {
     const template = (
       await import('./export_templates/swmm/SWMM_TEMPLATE.inp?raw')
     ).default as string;
-    const { area, rewind, cleanCoords } = await import('@turf/turf');
+    const {
+      area: turfArea,
+      rewind,
+      cleanCoords,
+      centroid,
+      bbox,
+      kinks,
+    } = await import('@turf/turf');
 
     const subcatchLines: string[] = [];
     const subareaLines: string[] = [];
     const infilLines: string[] = [];
     const polygonLines: string[] = [];
 
-    const grouped = new Map<
-      string,
-      { area: number; polygons: number[][][] }
-    >();
+    const sanitizeId = (s: string, i: number) =>
+      (s || `S${i + 1}`)
+        .trim()
+        .replace(/[^\w\-]/g, '_')
+        .replace(/_+/g, '_')
+        .slice(0, 31);
+
+    const grouped = new Map<string, { area: number; polygons: number[][][] }>();
 
     overlayLayer.geojson.features.forEach((f, i) => {
-      const id = ((f.properties as any)?.DA_NAME as string) || `S${i + 1}`;
-      const a = area(f as any) * 0.000247105; // acres
+      const raw = String((f.properties as any)?.DA_NAME ?? '');
+      const id = sanitizeId(raw, i);
       const geom = f.geometry;
       const rings: number[][][] =
         geom.type === 'Polygon'
           ? [geom.coordinates[0] as number[][]]
           : (geom as any).coordinates.map((p: any) => p[0] as number[][]);
+      const a = rings.reduce(
+        (sum, r) =>
+          sum +
+          Math.abs(
+            turfArea({
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [r] },
+              properties: {},
+            } as any)
+          ),
+        0
+      );
       const entry = grouped.get(id) || { area: 0, polygons: [] };
       entry.area += a;
       entry.polygons.push(...rings);
@@ -596,44 +619,118 @@ const App: React.FC = () => {
       return isClosed ? ring : [...ring, ring[0]];
     };
 
+    const isFinitePair = (p: number[]) =>
+      Number.isFinite(p[0]) && Number.isFinite(p[1]);
+
+    const uniq = (ring: number[][]) => {
+      const seen = new Set<string>();
+      const out: number[][] = [];
+      for (const p of ring) {
+        const k = `${p[0].toFixed(6)}|${p[1].toFixed(6)}`;
+        if (!seen.has(k)) {
+          seen.add(k);
+          out.push(p);
+        }
+      }
+      return out;
+    };
+
+    const reorderByAngle = (ring: number[][]) => {
+      const c = centroid({
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [ring] },
+        properties: {},
+      } as any).geometry.coordinates as number[];
+      return ring
+        .map(([x, y]) => ({ x, y, ang: Math.atan2(y - c[1], x - c[0]) }))
+        .sort((a, b) => a.ang - b.ang)
+        .map((p) => [p.x, p.y]);
+    };
+
     Array.from(grouped.entries())
       .sort(([a], [b]) => a.localeCompare(b))
-      .forEach(([id, { area: a, polygons }]) => {
-      const width = a * 100; // simple width approximation
-      subcatchLines.push(
-        `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
-      );
-      subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
-      infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
-
-      polygons.forEach((ring) => {
-        const gj = {
-          type: 'Feature',
-          geometry: { type: 'Polygon', coordinates: [ring] },
-          properties: {},
-        } as any;
-        const cleanedGj = cleanCoords(gj);
-        const rewound = rewind(cleanedGj, { reverse: false });
-        const ringCoords = rewound.geometry
-          .coordinates[0] as number[][];
-        const cleaned = ringCoords.filter(
-          (p, i, arr) =>
-            i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+      .forEach(([id, { area: areaSq, polygons }]) => {
+        polygons.sort(
+          (a, b) =>
+            Math.abs(
+              turfArea({
+                type: 'Feature',
+                geometry: { type: 'Polygon', coordinates: [b] },
+                properties: {},
+              } as any)
+            ) -
+            Math.abs(
+              turfArea({
+                type: 'Feature',
+                geometry: { type: 'Polygon', coordinates: [a] },
+                properties: {},
+              } as any)
+            )
         );
-        const closed = closeRing(cleaned);
-        closed.forEach(([x, y]) => {
-          polygonLines.push(`${id}\t${x}\t${y}`);
-        });
-      });
-    });
 
-    const bad = polygonLines.find(
-      (l) => l.trim().split(/\s+/).length !== 3
-    );
+        const ringLines: string[] = [];
+
+        polygons.forEach((ring) => {
+          const gj = {
+            type: 'Feature',
+            geometry: { type: 'Polygon', coordinates: [ring] },
+            properties: {},
+          } as any;
+          const cleanedGj = cleanCoords(gj);
+          const rewound = rewind(cleanedGj, { reverse: false });
+          const ringCoords = rewound.geometry.coordinates[0] as number[][];
+          const cleaned = ringCoords.filter(
+            (p, i, arr) =>
+              i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+          );
+          let ringToWrite = cleaned;
+          try {
+            if (kinks(gj as any).features.length) {
+              ringToWrite = reorderByAngle(cleaned);
+            }
+          } catch {}
+          const dedup = uniq(ringToWrite);
+          if (dedup.length < 3) {
+            addLog(`[POLYGONS] anillo degenerado en ${id}`, 'warn');
+            return;
+          }
+          const safeClosed = closeRing(dedup).filter(isFinitePair);
+          if (safeClosed.length < 4) {
+            addLog(
+              `[POLYGONS] Se descartó un anillo degenerado de ${id}`,
+              'warn'
+            );
+            return;
+          }
+          safeClosed.forEach(([x, y]) => ringLines.push(`${id}\t${x}\t${y}`));
+        });
+
+        if (ringLines.length === 0) return;
+
+        const a = areaSq * 0.000247105; // acres
+        const width = a * 100; // simple width approximation
+        subcatchLines.push(
+          `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
+        );
+        subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
+        infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
+        polygonLines.push(...ringLines);
+      });
+
+    const bad = polygonLines.find((l) => l.trim().split(/\s+/).length !== 3);
     if (bad) throw new Error(`[POLYGONS] mal formado: "${bad}"`);
 
+    const bad2 = polygonLines.find(
+      (l) =>
+        !/^\S+\s+-?\d+(\.\d+)?(e[+-]?\d+)?\s+-?\d+(\.\d+)?(e[+-]?\d+)?$/i.test(
+          l.trim()
+        )
+    );
+    if (bad2)
+      throw new Error(`[POLYGONS] token numérico inválido: "${bad2}"`);
+
     const replaceSection = (content: string, section: string, lines: string) => {
-      const regex = new RegExp(`\\[${section}\\][\\s\\S]*?(?=\\n\\[|$)`);
+      const regex = new RegExp(String.raw`\[${section}\][\s\S]*?(?=\r?\n\[|$)`);
       return content.replace(regex, `[${section}]\n${lines}\n`);
     };
 
@@ -667,6 +764,31 @@ const App: React.FC = () => {
       'POLYGONS',
       polygonHeader + polygonLines.join('\n')
     );
+
+    if (polygonLines.length) {
+      const allRings = polygonLines
+        .map((l) => l.split(/\s+/))
+        .map(([_, x, y]) => [Number(x), Number(y)]);
+      const [minX, minY, maxX, maxY] = bbox({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'MultiPoint', coordinates: allRings },
+            properties: {},
+          },
+        ],
+      } as any);
+      const dx = (maxX - minX) * 0.01;
+      const dy = (maxY - minY) * 0.01;
+      const mapBlock = `[MAP]\nDIMENSIONS       ${minX - dx} ${minY - dy}  ${
+        maxX + dx
+      } ${maxY + dy}\nUNITS            Meters\n`;
+      content = content.replace(
+        /\[MAP\][\s\S]*?(?=\r?\n\[|$)/,
+        mapBlock
+      );
+    }
 
     const blob = new Blob([content], { type: 'text/plain' });
     const filename = `${(projectName || 'project')}_${projectVersion}.inp`;


### PR DESCRIPTION
## Summary
- sanitize watershed IDs and compute areas per ring
- reject degenerate rings, reorder bow-ties, and validate numeric tokens
- compute map bounds from exported polygons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5e85d2c7c832093749de6e473495a