### PR TITLE
Add State Plane EPSG selection for export projections

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { STATE_PLANE_OPTIONS } from '../utils/stateplanes';
 
 interface ExportModalProps {
   onExportHydroCAD: () => void;
@@ -6,15 +7,39 @@ interface ExportModalProps {
   onExportShapefiles: () => void;
   onClose: () => void;
   exportEnabled?: boolean;
+  selectedEpsg: string;
+  onEpsgChange: (epsg: string) => void;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled }) => {
+const ExportModal: React.FC<ExportModalProps> = ({
+  onExportHydroCAD,
+  onExportSWMM,
+  onExportShapefiles,
+  onClose,
+  exportEnabled,
+  selectedEpsg,
+  onEpsgChange,
+}) => {
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
       <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
         <div className="flex justify-between items-center">
           <h2 className="text-lg font-semibold text-white">Export</h2>
           <button className="text-gray-400 hover:text-white" onClick={onClose}>✕</button>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-200 mb-1">State Plane / EPSG</label>
+          <select
+            value={selectedEpsg}
+            onChange={(e) => onEpsgChange(e.target.value)}
+            className="w-full bg-gray-700 text-white p-2 rounded"
+          >
+            {STATE_PLANE_OPTIONS.map((opt) => (
+              <option key={opt.epsg} value={opt.epsg}>
+                {opt.label} (EPSG:{opt.epsg})
+              </option>
+            ))}
+          </select>
         </div>
         <button
           onClick={onExportHydroCAD}

--- a/utils/stateplanes.ts
+++ b/utils/stateplanes.ts
@@ -1,0 +1,12 @@
+export interface StatePlaneOption {
+  label: string;
+  epsg: string;
+}
+
+export const STATE_PLANE_OPTIONS: StatePlaneOption[] = [
+  { label: 'NAD83 / California zone 3 (ftUS)', epsg: '2227' },
+  { label: 'NAD83 / Texas South Central (ftUS)', epsg: '2278' },
+  { label: 'NAD83 / New York Long Island (ftUS)', epsg: '2263' },
+  { label: 'NAD83 / Florida East (ftUS)', epsg: '2236' },
+  { label: 'NAD83 / Washington North (m)', epsg: '32148' }
+];


### PR DESCRIPTION
## Summary
- Add list of common State Plane EPSG codes
- Allow choosing State Plane/EPSG in export modal
- Reproject SWMM and shapefile exports to selected EPSG and set map units

## Testing
- `npm run build`
- `node tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5f648b7748320946360c8b4e1abec