### PR TITLE
feat: export pipes and catch basins to SWMM

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -617,6 +617,11 @@ const App: React.FC = () => {
     const subareaLines: string[] = [];
     const infilLines: string[] = [];
     const polygonLines: string[] = [];
+    const junctionLines: string[] = [];
+    const outfallLines: string[] = [];
+    const conduitLines: string[] = [];
+    const xsectionLines: string[] = [];
+    const coordLines: string[] = [];
 
     const grouped = new Map<
       string,
@@ -749,6 +754,107 @@ const App: React.FC = () => {
       validIds.has(l.split(/\s+/)[0])
     );
 
+    const getProp = (props: any, candidates: string[]) => {
+      if (!props) return undefined;
+      const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const keys = Object.keys(props);
+      for (const cand of candidates) {
+        const target = norm(cand);
+        for (const key of keys) {
+          const nk = norm(key);
+          if (nk === target || nk.includes(target) || target.includes(nk)) {
+            return (props as any)[key];
+          }
+        }
+      }
+      return undefined;
+    };
+
+    const jLayer = layers.find((l) => l.name === 'Catch Basins / Manholes');
+    const pLayer = layers.find((l) => l.name === 'Pipes');
+
+    const nodes: { id: string; coord: [number, number]; invert: number }[] = [];
+
+    if (jLayer) {
+      jLayer.geojson.features.forEach((f, i) => {
+        if (!f.geometry || f.geometry.type !== 'Point') return;
+        const raw = String(getProp(f.properties, ['Label']) ?? '');
+        const id = sanitizeId(raw, i);
+        const ground = Number(getProp(f.properties, ['Elevation Ground [ft]']) ?? 0);
+        const invert = Number(
+          getProp(f.properties, ['Elevation Invert[ft]', 'Elevation Invert [ft]']) ?? 0
+        );
+        const maxDepth = ground - invert;
+        const coord = project.forward(
+          (f.geometry as any).coordinates as [number, number]
+        );
+        const isOutfall = raw.toUpperCase().startsWith('OF');
+        if (isOutfall) {
+          outfallLines.push(`${id}\t${invert}\tFREE`);
+        } else {
+          junctionLines.push(`${id}\t${invert}\t${maxDepth}\t0\t0\t0`);
+        }
+        coordLines.push(`${id}\t${coord[0]}\t${coord[1]}`);
+        nodes.push({ id, coord, invert });
+      });
+    }
+
+    const findNearestNode = (pt: [number, number]) => {
+      let best = nodes[0];
+      let bestDist = Infinity;
+      for (const n of nodes) {
+        const dx = pt[0] - n.coord[0];
+        const dy = pt[1] - n.coord[1];
+        const d = Math.hypot(dx, dy);
+        if (d < bestDist) {
+          bestDist = d;
+          best = n;
+        }
+      }
+      return best;
+    };
+
+    const lineLength = (coords: number[][]) => {
+      let len = 0;
+      for (let i = 1; i < coords.length; i++) {
+        const [x1, y1] = project.forward(coords[i - 1] as [number, number]);
+        const [x2, y2] = project.forward(coords[i] as [number, number]);
+        len += Math.hypot(x2 - x1, y2 - y1);
+      }
+      return len;
+    };
+
+    if (pLayer && nodes.length) {
+      pLayer.geojson.features.forEach((f, i) => {
+        if (!f.geometry || f.geometry.type !== 'LineString') return;
+        const raw = String(getProp(f.properties, ['Label']) ?? '');
+        const id = sanitizeId(raw, i);
+        const coords = f.geometry.coordinates as number[][];
+        const start = project.forward(coords[0] as [number, number]);
+        const end = project.forward(coords[coords.length - 1] as [number, number]);
+        const from = findNearestNode(start);
+        const to = findNearestNode(end);
+        const len = lineLength(coords);
+        const rough = Number(
+          getProp(f.properties, ['Rougness', 'Roughness']) ?? 0
+        );
+        const diamIn = Number(getProp(f.properties, ['Diameter [in]']) ?? 0);
+        const invIn = Number(
+          getProp(f.properties, ['Elevation Invert In [ft]']) ?? 0
+        );
+        const invOut = Number(
+          getProp(f.properties, ['Elevation Invert Out [ft]']) ?? 0
+        );
+        const diamFt = diamIn / 12;
+        const inOffset = from ? invIn - from.invert : 0;
+        const outOffset = to ? invOut - to.invert : 0;
+        conduitLines.push(
+          `${id}\t${from?.id ?? ''}\t${to?.id ?? ''}\t${len.toFixed(3)}\t${rough}\t${inOffset.toFixed(3)}\t${outOffset.toFixed(3)}\t0\t0`
+        );
+        xsectionLines.push(`${id}\tCIRCULAR\t${diamFt}\t0\t0\t0\t1`);
+      });
+    }
+
     const replaceSection = (content: string, section: string, lines: string) => {
       const regex = new RegExp(String.raw`\[${section}\][\s\S]*?(?=\r?\n\[|$)`);
       return content.replace(regex, `[${section}]\n${lines}\n`);
@@ -794,11 +900,31 @@ const App: React.FC = () => {
       'POLYGONS',
       polygonHeader + filteredPolygonLines.join('\n')
     );
-    content = replaceSection(content, 'JUNCTIONS', junctionHeader);
-    content = replaceSection(content, 'OUTFALLS', outfallHeader);
-    content = replaceSection(content, 'CONDUITS', conduitHeader);
-    content = replaceSection(content, 'XSECTIONS', xsectionHeader);
-    content = replaceSection(content, 'COORDINATES', coordHeader);
+    content = replaceSection(
+      content,
+      'JUNCTIONS',
+      junctionHeader + junctionLines.join('\n')
+    );
+    content = replaceSection(
+      content,
+      'OUTFALLS',
+      outfallHeader + outfallLines.join('\n')
+    );
+    content = replaceSection(
+      content,
+      'CONDUITS',
+      conduitHeader + conduitLines.join('\n')
+    );
+    content = replaceSection(
+      content,
+      'XSECTIONS',
+      xsectionHeader + xsectionLines.join('\n')
+    );
+    content = replaceSection(
+      content,
+      'COORDINATES',
+      coordHeader + coordLines.join('\n')
+    );
 
     if (filteredPolygonLines.length) {
       const allRings = filteredPolygonLines
@@ -840,7 +966,12 @@ const App: React.FC = () => {
     }, [addLog, layers, projectName, projectVersion, projection]);
 
   const handleExportShapefiles = useCallback(async () => {
-    const processedLayers = layers.filter(l => l.category === 'Process');
+    const processedLayers = layers.filter(
+      l =>
+        l.category === 'Process' ||
+        l.name === 'Pipes' ||
+        l.name === 'Catch Basins / Manholes'
+    );
     if (processedLayers.length === 0) {
       addLog('No processed layers to export', 'error');
       return;

--- a/components/FieldMapModal.tsx
+++ b/components/FieldMapModal.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react';
+
+interface FieldMapModalProps {
+  layerName: string;
+  properties: Record<string, any>;
+  onConfirm: (mapping: Record<string, string>) => void;
+  onCancel: () => void;
+}
+
+const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, onConfirm, onCancel }) => {
+  const fields = Object.keys(properties || {});
+  const [mapping, setMapping] = useState<Record<string, string>>({});
+
+  const required = layerName === 'Pipes'
+    ? [
+        { key: 'label', label: 'Label' },
+        { key: 'inv_in', label: 'Elevation Invert In [ft]' },
+        { key: 'inv_out', label: 'Elevation Invert Out [ft]' },
+        { key: 'diameter', label: 'Diameter [in]' },
+        { key: 'roughness', label: 'Roughness' },
+      ]
+    : [
+        { key: 'label', label: 'Label' },
+        { key: 'ground', label: 'Elevation Ground [ft]' },
+        { key: 'invert', label: 'Elevation Invert[ft]' },
+      ];
+
+  useEffect(() => {
+    const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const guess: Record<string, string> = {};
+    required.forEach(r => {
+      const target = norm(r.label);
+      const found = fields.find(f => {
+        const nf = norm(f);
+        return nf === target || nf.includes(target) || target.includes(nf);
+      });
+      if (found) guess[r.key] = found;
+    });
+    setMapping(guess);
+  }, [fields, layerName]);
+
+  const handleChange = (key: string, value: string) => {
+    setMapping(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = () => {
+    onConfirm(mapping);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2100]">
+      <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-80 space-y-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-white">Map Fields</h2>
+          <button className="text-gray-400 hover:text-white" onClick={onCancel}>✕</button>
+        </div>
+        {required.map(r => (
+          <div key={r.key}>
+            <label className="block text-sm text-gray-300 mb-1">{r.label}</label>
+            <select
+              className="w-full bg-gray-700 text-white p-2 rounded"
+              value={mapping[r.key] || ''}
+              onChange={e => handleChange(r.key, e.target.value)}
+            >
+              <option value="">-- Select --</option>
+              {fields.map(f => (
+                <option key={f} value={f}>{f}</option>
+              ))}
+            </select>
+          </div>
+        ))}
+        <button
+          onClick={handleSubmit}
+          className="w-full bg-cyan-600 hover:bg-cyan-700 text-white px-4 py-2 rounded"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FieldMapModal;

--- a/components/LayerPreview.tsx
+++ b/components/LayerPreview.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import type { FeatureCollection } from 'geojson';
-import { ALL_LAYER_NAMES, KNOWN_LAYER_NAMES, OTHER_CATEGORY } from '../utils/constants';
+import { ALL_LAYER_NAMES, OTHER_CATEGORY, SUPPORTED_LAYER_NAMES } from '../utils/constants';
 
 interface LayerPreviewProps {
   data: FeatureCollection;
@@ -14,7 +14,7 @@ const LayerPreview: React.FC<LayerPreviewProps> = ({ data, fileName, detectedNam
   const [category, setCategory] = useState<string>(OTHER_CATEGORY);
 
   useEffect(() => {
-    if (KNOWN_LAYER_NAMES.includes(detectedName)) {
+    if (SUPPORTED_LAYER_NAMES.includes(detectedName)) {
       setCategory(detectedName);
     } else {
       setCategory(OTHER_CATEGORY);

--- a/types.ts
+++ b/types.ts
@@ -12,6 +12,7 @@ export interface LayerData {
   fillColor: string;
   fillOpacity: number;
   category?: string;
+  fieldMap?: Record<string, string>;
 }
 
 export interface LogEntry {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,6 +2,9 @@ export const ARCHIVE_NAME_MAP: Record<string, string> = {
   'da.zip': 'Drainage Areas',
   'landcover.zip': 'Land Cover',
   'lod.zip': 'LOD',
+  'pipes.zip': 'Pipes',
+  'cb.zip': 'Catch Basins / Manholes',
+  'manholes.zip': 'Catch Basins / Manholes',
 };
 
 export const KNOWN_LAYER_NAMES = [
@@ -11,5 +14,8 @@ export const KNOWN_LAYER_NAMES = [
   'Soil Layer from Web Soil Survey',
 ];
 
+export const OPTIONAL_LAYER_NAMES = ['Pipes', 'Catch Basins / Manholes'];
+
 export const OTHER_CATEGORY = 'Other';
-export const ALL_LAYER_NAMES = [...KNOWN_LAYER_NAMES, OTHER_CATEGORY];
+export const ALL_LAYER_NAMES = [...KNOWN_LAYER_NAMES, ...OPTIONAL_LAYER_NAMES, OTHER_CATEGORY];
+export const SUPPORTED_LAYER_NAMES = [...KNOWN_LAYER_NAMES, ...OPTIONAL_LAYER_NAMES];


### PR DESCRIPTION
## Summary
- map pipe and catch basin archives to dedicated layers and surface them in upload dropdown
- flexibly resolve pipe and junction field names to build SWMM JUNCTIONS and CONDUITS with offsets
- include catch basin and pipe layers in shapefile exports

## Testing
- `npm test` *(fails: Missing script)*
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b601faaa188320a3b9972597a9953b