### PR TITLE
feat: export pipes and junctions to SWMM

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,6 +2,9 @@ export const ARCHIVE_NAME_MAP: Record<string, string> = {
   'da.zip': 'Drainage Areas',
   'landcover.zip': 'Land Cover',
   'lod.zip': 'LOD',
+  'pipes.zip': 'Pipes',
+  'cb.zip': 'Catch Basins / Manholes',
+  'manholes.zip': 'Catch Basins / Manholes',
 };
 
 export const KNOWN_LAYER_NAMES = [
@@ -9,6 +12,8 @@ export const KNOWN_LAYER_NAMES = [
   'Land Cover',
   'LOD',
   'Soil Layer from Web Soil Survey',
+  'Pipes',
+  'Catch Basins / Manholes',
 ];
 
 export const OTHER_CATEGORY = 'Other';


### PR DESCRIPTION
## Summary
- map `pipes.zip`, `cb.zip`, and `manholes.zip` uploads to "Pipes" or "Catch Basins / Manholes" instead of Other
- use token-based matching for pipe and junction attributes and compute conduit offsets
- include pipe and junction layers in processed shapefile exports

## Testing
- `npm test` *(fails: Missing script)*
- `node --test tests/intersect.test.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b601faaa188320a3b9972597a9953b