### PR TITLE
Document backend dataset requirements per process

### DIFF
--- a/process-file-map.json
+++ b/process-file-map.json
@@ -1,0 +1,14 @@
+{
+  "exportHydroCAD": {
+    "requires": ["drainageArea", "lod", "landCover", "wss"],
+    "excludes": ["catchBasinManhole", "pipes"]
+  },
+  "exportSWMM": {
+    "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
+    "excludes": []
+  },
+  "exportShapefiles": {
+    "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
+    "excludes": []
+  }
+}

--- a/server.js
+++ b/server.js
@@ -3,6 +3,12 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { intersect as turfIntersect, area as turfArea } from '@turf/turf';
+import processFileMap from './process-file-map.json' assert { type: 'json' };
+
+// processFileMap maps backend processes (e.g., exportHydroCAD, exportSWMM,
+// exportShapefiles) to the spatial data layers they require. Update
+// process-file-map.json whenever process requirements change so future
+// automation can determine which files are needed for each operation.
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## Summary
- map dataset needs for shapefile export in `process-file-map.json`
- clarify `server.js` comment to mention supported export processes

## Testing
- `node --test tests/intersect.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60e860f108320991cea9df0332a7a