### PR TITLE
feat: standardize catch basin manhole fields

### DIFF
--- a/components/FieldMapModal.tsx
+++ b/components/FieldMapModal.tsx
@@ -22,7 +22,10 @@ const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, on
     : [
         { key: 'label', label: 'Label' },
         { key: 'ground', label: 'Elevation Ground [ft]' },
-        { key: 'invert', label: 'Elevation Invert[ft]' },
+        { key: 'inv_n', label: 'Invert N [ft]' },
+        { key: 'inv_s', label: 'Invert S [ft]' },
+        { key: 'inv_e', label: 'Invert E [ft]' },
+        { key: 'inv_w', label: 'Invert W [ft]' },
       ];
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- map directional invert fields and derive lowest outlet
- auto-label unnamed structures
- compute node inverts from directional values during SWMM export

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b612ccb9d48320848d450163cd9a91