### PR TITLE
feat: map catch basin invert directions

### DIFF
--- a/components/FieldMapModal.tsx
+++ b/components/FieldMapModal.tsx
@@ -11,19 +11,29 @@ const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, on
   const fields = Object.keys(properties || {});
   const [mapping, setMapping] = useState<Record<string, string>>({});
 
-  const required = layerName === 'Pipes'
-    ? [
-        { key: 'label', label: 'Label' },
-        { key: 'inv_in', label: 'Elevation Invert In [ft]' },
-        { key: 'inv_out', label: 'Elevation Invert Out [ft]' },
-        { key: 'diameter', label: 'Diameter [in]' },
-        { key: 'roughness', label: 'Roughness' },
-      ]
-    : [
-        { key: 'label', label: 'Label' },
-        { key: 'ground', label: 'Elevation Ground [ft]' },
-        { key: 'invert', label: 'Elevation Invert[ft]' },
-      ];
+  const required =
+    layerName === 'Pipes'
+      ? [
+          { key: 'label', label: 'Label' },
+          { key: 'inv_in', label: 'Elevation Invert In [ft]' },
+          { key: 'inv_out', label: 'Elevation Invert Out [ft]' },
+          { key: 'diameter', label: 'Diameter [in]' },
+          { key: 'roughness', label: 'Roughness' },
+        ]
+      : layerName === 'Catch Basins / Manholes'
+      ? [
+          { key: 'label', label: 'Label' },
+          { key: 'ground', label: 'Elevation Ground [ft]' },
+          { key: 'inv_n', label: 'Invert N [ft]' },
+          { key: 'inv_s', label: 'Invert S [ft]' },
+          { key: 'inv_e', label: 'Invert E [ft]' },
+          { key: 'inv_w', label: 'Invert W [ft]' },
+        ]
+      : [
+          { key: 'label', label: 'Label' },
+          { key: 'ground', label: 'Elevation Ground [ft]' },
+          { key: 'invert', label: 'Elevation Invert[ft]' },
+        ];
 
   useEffect(() => {
     const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');


### PR DESCRIPTION
## Summary
- allow mapping of directional inverts for catch basins/manholes
- compute and store lowest invert as `Inv Out [ft]`
- export SWMM nodes using computed outlet invert

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b612ccb9d48320848d450163cd9a91