### PR TITLE
Clean pipe and CB/MH attributes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -241,7 +241,6 @@ const App: React.FC = () => {
           return {
             ...f,
             properties: {
-              ...props,
               'Label': label,
               'Elevation Invert In [ft]': invIn,
               'Elevation Invert Out [ft]': invOut,
@@ -282,7 +281,6 @@ const App: React.FC = () => {
           return {
             ...f,
             properties: {
-              ...props,
               'Label': label,
               'Elevation Ground [ft]': ground,
               'Invert N [ft]': invN,

--- a/components/FieldMapModal.tsx
+++ b/components/FieldMapModal.tsx
@@ -9,7 +9,17 @@ interface FieldMapModalProps {
 
 const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, onConfirm, onCancel }) => {
   const fields = Object.keys(properties || {});
-  const [mapping, setMapping] = useState<Record<string, string>>({});
+  const [mapping, setMapping] = useState<Record<string, string>>(() => {
+    if (layerName === 'Catch Basins / Manholes') {
+      const lowerMap = Object.fromEntries(fields.map(f => [f.toLowerCase(), f]));
+      const init: Record<string, string> = {};
+      ['inv_n', 'inv_s', 'inv_e', 'inv_w'].forEach(k => {
+        if (lowerMap[k]) init[k] = lowerMap[k];
+      });
+      return init;
+    }
+    return {};
+  });
 
   let required: { key: string; label: string }[] = [];
   if (layerName === 'Pipes') {


### PR DESCRIPTION
## Summary
- Remove leftover shapefile attributes when loading Pipes layer, keeping only label, invert elevations, diameter and roughness
- Remove extraneous attributes from Catch Basins / Manholes layer so only essential elevations remain

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b61dd946108320a8cd8719c97b8fa5