### PR TITLE
Add 3D pipe network viewer

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,8 @@ interface HeaderProps {
   computeEnabled?: boolean;
   onExport?: () => void;
   exportEnabled?: boolean;
+  onShow3D?: () => void;
+  show3DEnabled?: boolean;
   projectName: string;
   onProjectNameChange: (name: string) => void;
   projectVersion: string;
@@ -17,6 +19,8 @@ const Header: React.FC<HeaderProps> = ({
   computeEnabled,
   onExport,
   exportEnabled,
+  onShow3D,
+  show3DEnabled,
   projectName,
   onProjectNameChange,
   projectVersion,
@@ -53,6 +57,18 @@ const Header: React.FC<HeaderProps> = ({
           }
         >
           Export
+        </button>
+        <button
+          onClick={onShow3D}
+          disabled={!show3DEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (show3DEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          3D PIPE NETWORK
         </button>
       </div>
       <div className="absolute right-4 flex items-center space-x-2">

--- a/components/PipeNetwork3D.tsx
+++ b/components/PipeNetwork3D.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+
+const PipeNetwork3D: React.FC = () => {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x202020);
+
+    const width = mount.clientWidth;
+    const height = mount.clientHeight;
+    const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    mount.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const dataStr = localStorage.getItem('pipe-network-data');
+    const allPoints: THREE.Vector3[] = [];
+    const meshes: THREE.Object3D[] = [];
+    if (dataStr) {
+      try {
+        const data = JSON.parse(dataStr);
+        const cb = data.cbLayer?.features || [];
+        const pipes = data.pipesLayer?.features || [];
+        const sphereGeom = new THREE.SphereGeometry(0.5, 16, 16);
+        const sphereMat = new THREE.MeshStandardMaterial({ color: 0xff0000 });
+        cb.forEach((f: any) => {
+          if (f.geometry?.type === 'Point') {
+            const [x, y] = f.geometry.coordinates;
+            const z = Number(f.properties?.['Inv Out [ft]']) || 0;
+            const v = new THREE.Vector3(x, y, z);
+            allPoints.push(v);
+            const m = new THREE.Mesh(sphereGeom, sphereMat);
+            m.position.copy(v);
+            meshes.push(m);
+          }
+        });
+        const lineMat = new THREE.LineBasicMaterial({ color: 0x00aaff });
+        pipes.forEach((f: any) => {
+          if (f.geometry?.type === 'LineString') {
+            const coords = f.geometry.coordinates as number[][];
+            const zStart = Number(f.properties?.['Elevation Invert In [ft]']) || 0;
+            const zEnd = Number(f.properties?.['Elevation Invert Out [ft]']) || 0;
+            const pts = coords.map((c, i) => {
+              const t = coords.length > 1 ? i / (coords.length - 1) : 0;
+              const z = zStart + (zEnd - zStart) * t;
+              const v = new THREE.Vector3(c[0], c[1], z);
+              allPoints.push(v);
+              return v;
+            });
+            const geom = new THREE.BufferGeometry().setFromPoints(pts);
+            const line = new THREE.Line(geom, lineMat);
+            meshes.push(line);
+          }
+        });
+      } catch (err) {
+        // ignore parse errors
+      }
+    }
+
+    const box = new THREE.Box3().setFromPoints(allPoints);
+    const center = box.getCenter(new THREE.Vector3());
+    meshes.forEach(obj => {
+      if (obj instanceof THREE.Line) {
+        const pos = (obj.geometry as THREE.BufferGeometry).getAttribute('position') as THREE.BufferAttribute;
+        for (let i = 0; i < pos.count; i++) {
+          pos.setX(i, pos.getX(i) - center.x);
+          pos.setY(i, pos.getY(i) - center.y);
+          pos.setZ(i, pos.getZ(i) - center.z);
+        }
+        pos.needsUpdate = true;
+      } else {
+        obj.position.sub(center);
+      }
+      scene.add(obj);
+    });
+
+    const size = box.getSize(new THREE.Vector3()).length();
+    camera.position.set(0, 0, size * 1.5 || 50);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+    scene.add(ambient);
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    const handleResize = () => {
+      const w = mount.clientWidth;
+      const h = mount.clientHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      mount.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return <div ref={mountRef} style={{ width: '100vw', height: '100vh' }} />;
+};
+
+export default PipeNetwork3D;

--- a/index.tsx
+++ b/index.tsx
@@ -1,17 +1,18 @@
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import PipeNetwork3D from './components/PipeNetwork3D';
 import '@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);
+const path = window.location.pathname;
 root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    {path === '/3d' ? <PipeNetwork3D /> : <App />}
+  </React.StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
         "react-leaflet-google-layer": "^4.0.0",
-        "shpjs": "^6.1.0"
+        "shpjs": "^6.1.0",
+        "three": "^0.180.0"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -4560,6 +4561,12 @@
       "dependencies": {
         "tinyqueue": "^2.0.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
     "react-leaflet-google-layer": "^4.0.0",
-    "shpjs": "^6.1.0"
+    "shpjs": "^6.1.0",
+    "three": "^0.180.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- add 3D Pipe Network button and enable logic after CB/MH and pipes layers load
- launch new tab rendering pipe network using three.js with orbit controls
- route `/3d` to new viewer component

## Testing
- `npm test` *(fails: Missing script)*
- `node --test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ad2ee4cc8320be8cc4bbdefbe370