### PR TITLE
feat: add 3D pipe network viewer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -82,6 +82,10 @@ const App: React.FC = () => {
   const computeEnabled =
     requiredLayers.every(name => layers.some(l => l.name === name)) && lodValid;
 
+  const cbIndex = layers.findIndex(l => l.name === 'Catch Basins / Manholes');
+  const pipesIndex = layers.findIndex(l => l.name === 'Pipes');
+  const pipe3DEnabled = cbIndex !== -1 && pipesIndex !== -1 && cbIndex < pipesIndex;
+
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' as const }]);
   }, []);
@@ -1239,6 +1243,136 @@ const App: React.FC = () => {
     setExportModalOpen(false);
   }, [addLog, layers, projectName, projectVersion, projection]);
 
+  const handleView3D = useCallback(() => {
+    const jLayer = layers.find((l) => l.name === 'Catch Basins / Manholes');
+    const pLayer = layers.find((l) => l.name === 'Pipes');
+    if (!jLayer || !pLayer) return;
+    const projectFn = proj4('EPSG:4326', projection.proj4);
+    const nodes = jLayer.geojson.features
+      .filter((f) => f.geometry && f.geometry.type === 'Point')
+      .map((f) => {
+        const [x, y] = projectFn.forward(
+          (f.geometry as any).coordinates as [number, number]
+        );
+        const props = f.properties as any;
+        const ground = Number(props?.['Elevation Ground [ft]'] ?? 0);
+        const invOut = Number(props?.['Inv Out [ft]'] ?? 0);
+        return { x, y, ground, invOut, diam: 4 };
+      });
+    const pipes = pLayer.geojson.features
+      .filter(
+        (f) =>
+          f.geometry &&
+          (f.geometry.type === 'LineString' ||
+            f.geometry.type === 'MultiLineString')
+      )
+      .map((f) => {
+        const coords =
+          f.geometry.type === 'LineString'
+            ? ((f.geometry as any).coordinates as number[][])
+            : ((f.geometry as any).coordinates[0] as number[][]);
+        const [sx, sy] = projectFn.forward(coords[0] as [number, number]);
+        const [ex, ey] = projectFn.forward(
+          coords[coords.length - 1] as [number, number]
+        );
+        const invIn = Number(
+          (f.properties as any)?.['Elevation Invert In [ft]'] ?? 0
+        );
+        const invOut = Number(
+          (f.properties as any)?.['Elevation Invert Out [ft]'] ?? 0
+        );
+        const diam = Number((f.properties as any)?.['Diameter [in]'] ?? 0) / 12;
+        return {
+          start: { x: sx, y: sy, z: invIn },
+          end: { x: ex, y: ey, z: invOut },
+          diam,
+        };
+      });
+    if (nodes.length === 0 && pipes.length === 0) {
+      addLog('No pipe network data to display', 'error');
+      return;
+    }
+    const data = { nodes, pipes };
+    const scriptLines = [
+      `const data=${JSON.stringify(data)};`,
+      'const xs=[],ys=[],zs=[];',
+      'data.nodes.forEach(n=>{',
+      '  xs.push(n.x);ys.push(n.y);zs.push(n.ground,n.invOut);',
+      '});',
+      'data.pipes.forEach(p=>{',
+      '  xs.push(p.start.x,p.end.x);',
+      '  ys.push(p.start.y,p.end.y);',
+      '  zs.push(p.start.z,p.end.z);',
+      '});',
+      'let minX=Math.min(...xs),maxX=Math.max(...xs);',
+      'let minY=Math.min(...ys),maxY=Math.max(...ys);',
+      'let minZ=Math.min(...zs),maxZ=Math.max(...zs);',
+      'if(!isFinite(minX)){minX=maxX=minY=maxY=minZ=maxZ=0;}',
+      'const cx=(maxX+minX)/2,cy=(maxY+minY)/2,cz=(maxZ+minZ)/2;',
+      'const size=Math.max(maxX-minX,maxY-minY,maxZ-minZ)||1;',
+      'data.nodes.forEach(n=>{n.x-=cx;n.y-=cy;n.ground-=cz;n.invOut-=cz;});',
+      'data.pipes.forEach(p=>{p.start.x-=cx;p.start.y-=cy;p.start.z-=cz;p.end.x-=cx;p.end.y-=cy;p.end.z-=cz;});',
+      'const scene=new THREE.Scene();scene.background=new THREE.Color(0x000000);',
+      'const camera=new THREE.PerspectiveCamera(60,window.innerWidth/window.innerHeight,0.1,100000);',
+      'const renderer=new THREE.WebGLRenderer({antialias:true});',
+      'renderer.setSize(window.innerWidth,window.innerHeight);',
+      'renderer.setClearColor(0x000000);',
+      'document.body.appendChild(renderer.domElement);',
+      'const controls=new THREE.OrbitControls(camera,renderer.domElement);',
+      'function reset(){camera.position.set(0,-size,size);controls.target.set(0,0,0);controls.update();}',
+      'reset();',
+      'const amb=new THREE.AmbientLight(0xffffff,0.6);scene.add(amb);',
+      'const dir=new THREE.DirectionalLight(0xffffff,0.8);dir.position.set(100,100,100);scene.add(dir);',
+      'data.nodes.forEach(n=>{',
+      '  const s=new THREE.Vector3(n.x,n.y,n.invOut);',
+      '  const e=new THREE.Vector3(n.x,n.y,n.ground);',
+      '  const dv=new THREE.Vector3().subVectors(e,s);',
+      '  const g=new THREE.CylinderGeometry(n.diam/2,n.diam/2,dv.length(),16,false);',
+      '  const m=new THREE.MeshStandardMaterial({color:0xffffff});',
+      '  const mesh=new THREE.Mesh(g,m);',
+      '  const axis=new THREE.Vector3(0,1,0);',
+      '  mesh.quaternion.setFromUnitVectors(axis,dv.clone().normalize());',
+      '  mesh.position.copy(s.clone().add(dv.multiplyScalar(0.5)));',
+      '  scene.add(mesh);',
+      '});',
+      'data.pipes.forEach(p=>{',
+      '  const s=new THREE.Vector3(p.start.x,p.start.y,p.start.z);',
+      '  const e=new THREE.Vector3(p.end.x,p.end.y,p.end.z);',
+      '  const dv=new THREE.Vector3().subVectors(e,s);',
+      '  const g=new THREE.CylinderGeometry(p.diam/2,p.diam/2,dv.length(),8,false);',
+      '  const m=new THREE.MeshStandardMaterial({color:0xffffff});',
+      '  const mesh=new THREE.Mesh(g,m);',
+      '  const axis=new THREE.Vector3(0,1,0);',
+      '  mesh.quaternion.setFromUnitVectors(axis,dv.clone().normalize());',
+      '  mesh.position.copy(s.clone().add(dv.multiplyScalar(0.5)));',
+      '  scene.add(mesh);',
+      '});',
+      'function animate(){requestAnimationFrame(animate);renderer.render(scene,camera);}',
+      'animate();',
+      'window.addEventListener("resize",()=>{',
+      '  camera.aspect=window.innerWidth/window.innerHeight;',
+      '  camera.updateProjectionMatrix();',
+      '  renderer.setSize(window.innerWidth,window.innerHeight);',
+      '});',
+      'document.getElementById("center").addEventListener("click",reset);'
+    ];
+    const script = scriptLines.join('\n');
+    const html =
+      `<!DOCTYPE html><html><head><title>3D Pipe Network</title>` +
+      `<style>html,body{margin:0;height:100%;overflow:hidden;background:#000;color:#fff}` +
+      `#center{position:absolute;top:10px;left:10px;z-index:1}</style></head><body>` +
+      `<button id="center">Center View</button>` +
+      `<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>` +
+      `<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/examples/js/controls/OrbitControls.min.js"></script>` +
+      `<script>${script}<\/script></body></html>`;
+    const win = window.open('', '_blank');
+    if (win) {
+      win.document.write(html);
+      win.document.close();
+      addLog('3D Pipe Network viewer opened');
+    }
+  }, [addLog, layers, projection]);
+
   return (
     <div className="flex flex-col h-screen bg-gray-900 text-gray-100 font-sans">
       <Header
@@ -1246,6 +1380,8 @@ const App: React.FC = () => {
         onCompute={handleCompute}
         exportEnabled={computeSucceeded}
         onExport={() => setExportModalOpen(true)}
+        onView3D={handleView3D}
+        view3DEnabled={pipe3DEnabled}
         projectName={projectName}
         onProjectNameChange={setProjectName}
         projectVersion={projectVersion}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,6 +7,8 @@ interface HeaderProps {
   computeEnabled?: boolean;
   onExport?: () => void;
   exportEnabled?: boolean;
+  onView3D?: () => void;
+  view3DEnabled?: boolean;
   projectName: string;
   onProjectNameChange: (name: string) => void;
   projectVersion: string;
@@ -17,6 +19,8 @@ const Header: React.FC<HeaderProps> = ({
   computeEnabled,
   onExport,
   exportEnabled,
+  onView3D,
+  view3DEnabled,
   projectName,
   onProjectNameChange,
   projectVersion,
@@ -53,6 +57,18 @@ const Header: React.FC<HeaderProps> = ({
           }
         >
           Export
+        </button>
+        <button
+          onClick={onView3D}
+          disabled={!view3DEnabled}
+          className={
+            'font-semibold px-4 py-1 rounded ' +
+            (view3DEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          3D PIPE NETWORK
         </button>
       </div>
       <div className="absolute right-4 flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- add header button to launch a 3D Pipe Network view
- generate three.js scene for pipes and nodes in a new browser tab
- draw catch basins/manholes as 48" cylinders with correct depth and center view control
- render network data with white cylinders on a black background and support MultiLineString geometries

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad2ee4cc8320be8cc4bbdefbe370