### PR TITLE
Filter invalid pipe network elements in 3D view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1259,10 +1259,13 @@ const App: React.FC = () => {
           (f.geometry as any).coordinates as [number, number]
         );
         const props = f.properties as any;
-        const ground = Number(props?.['Elevation Ground [ft]'] ?? 0);
-        const invOut = Number(props?.['Inv Out [ft]'] ?? 0);
+        const ground = parseFloat(props?.['Elevation Ground [ft]']);
+        const invOut = parseFloat(props?.['Inv Out [ft]']);
+        if (!isFinite(ground) || !isFinite(invOut)) return null;
         return { x, y, ground, invOut, diam: 4 };
-      });
+      })
+      .filter((n): n is { x: number; y: number; ground: number; invOut: number; diam: number } => n !== null);
+
     const pipes = pLayer.geojson.features
       .filter(
         (f) =>
@@ -1279,21 +1282,31 @@ const App: React.FC = () => {
         const [ex, ey] = projectFn.forward(
           coords[coords.length - 1] as [number, number]
         );
-        const invIn = Number(
-          (f.properties as any)?.['Elevation Invert In [ft]'] ?? 0
+        const invIn = parseFloat(
+          (f.properties as any)?.['Elevation Invert In [ft]']
         );
-        const invOut = Number(
-          (f.properties as any)?.['Elevation Invert Out [ft]'] ?? 0
+        const invOut = parseFloat(
+          (f.properties as any)?.['Elevation Invert Out [ft]']
         );
-        const diam = Number((f.properties as any)?.['Diameter [in]'] ?? 0) / 12;
+        const diam =
+          parseFloat((f.properties as any)?.['Diameter [in]']) / 12;
+        if (!isFinite(invIn) || !isFinite(invOut) || !isFinite(diam)) return null;
         return {
           start: { x: sx, y: sy, z: invIn },
           end: { x: ex, y: ey, z: invOut },
           diam,
         };
-      });
+      })
+      .filter(
+        (p): p is {
+          start: { x: number; y: number; z: number };
+          end: { x: number; y: number; z: number };
+          diam: number;
+        } => p !== null
+      );
+
     if (nodes.length === 0 && pipes.length === 0) {
-      addLog('No pipe network data to display', 'error');
+      addLog('No pipe network data with valid numeric values to display', 'error');
       return;
     }
     const data = { nodes, pipes };


### PR DESCRIPTION
## Summary
- Ignore pipe network nodes and pipes without valid numeric elevation or diameter data in the 3D viewer
- Log an error when no valid pipe network features are available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9f74991fc8320a46ee49824d5f4d2