### PR TITLE
Fix 3D viewer cylinder rendering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1412,8 +1412,7 @@ const App: React.FC = () => {
           n.diam / 2,
           n.diam / 2,
           dv.length(),
-          16,
-          false
+          16
         );
         const m = new THREE.MeshStandardMaterial({ color: 0xffffff });
         const mesh = new THREE.Mesh(g, m);
@@ -1431,8 +1430,7 @@ const App: React.FC = () => {
           p.diam / 2,
           p.diam / 2,
           dv.length(),
-          8,
-          false
+          8
         );
         const m = new THREE.MeshStandardMaterial({ color: 0xffffff });
         const mesh = new THREE.Mesh(g, m);


### PR DESCRIPTION
## Summary
- draw catch basins/manholes as full white cylinders
- render pipes as complete white cylinders instead of end caps

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fa19525883208e21e7b0bfb6c0ff