### PR TITLE
Align 3D pipe network controls with Google Earth style

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1351,6 +1351,15 @@ const App: React.FC = () => {
 
       const controls = new THREE.OrbitControls(camera, renderer.domElement);
       controls.enableDamping = true;
+      controls.mouseButtons = {
+        LEFT: THREE.MOUSE.PAN,
+        RIGHT: THREE.MOUSE.ROTATE,
+        MIDDLE: THREE.MOUSE.DOLLY,
+      };
+      controls.touches = {
+        ONE: THREE.TOUCH.PAN,
+        TWO: THREE.TOUCH.DOLLY_ROTATE,
+      };
 
       const xs: number[] = [], ys: number[] = [], zs: number[] = [];
       data.nodes.forEach((n) => {


### PR DESCRIPTION
## Summary
- Configure 3D pipe network OrbitControls to pan with left drag, rotate with right drag, and zoom with middle drag to mimic Google Earth desktop behavior
- Add touch gesture mappings for panning and dolly/rotate combinations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fd29c6cc8320a26cdd564adffc52