### PR TITLE
Mimic Google Earth controls for pipe network 3D view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1349,8 +1349,15 @@ const App: React.FC = () => {
         100000
       );
 
-      const controls = new THREE.OrbitControls(camera, renderer.domElement);
+      const controls = new THREE.MapControls(camera, renderer.domElement);
       controls.enableDamping = true;
+      controls.dampingFactor = 0.05;
+      controls.screenSpacePanning = true;
+      controls.mouseButtons = {
+        LEFT: THREE.MOUSE.PAN,
+        MIDDLE: THREE.MOUSE.DOLLY,
+        RIGHT: THREE.MOUSE.ROTATE,
+      };
 
       const xs: number[] = [], ys: number[] = [], zs: number[] = [];
       data.nodes.forEach((n) => {


### PR DESCRIPTION
## Summary
- Switch 3D pipe network viewer to Google Earth style interactions via `MapControls`
- Enable panning, rotating, and zooming using familiar Google Earth mouse bindings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fd29c6cc8320a26cdd564adffc52