### PR TITLE
Adjust 3D pipe viewer controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1351,6 +1351,16 @@ const App: React.FC = () => {
 
       const controls = new THREE.OrbitControls(camera, renderer.domElement);
       controls.enableDamping = true;
+      controls.zoomToCursor = true;
+      controls.mouseButtons = {
+        LEFT: THREE.MOUSE.PAN,
+        MIDDLE: THREE.MOUSE.DOLLY,
+        RIGHT: THREE.MOUSE.ROTATE,
+      };
+      controls.touches = {
+        ONE: THREE.TOUCH.PAN,
+        TWO: THREE.TOUCH.DOLLY_ROTATE,
+      };
 
       const xs: number[] = [], ys: number[] = [], zs: number[] = [];
       data.nodes.forEach((n) => {


### PR DESCRIPTION
## Summary
- make 3D pipe network viewer controls match Google Earth with pan on left drag, rotate on right drag, zoom to cursor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fd29c6cc8320a26cdd564adffc52