### PR TITLE
Enable SWMM export for pipe network

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -90,6 +90,12 @@ const App: React.FC = () => {
     !!pipesLayer &&
     pipesLayer.geojson.features.length > 0;
 
+  const exportHydroCADEnabled = computeSucceeded;
+  const exportShapefilesEnabled = computeSucceeded;
+  const exportSWMMEnabled = computeSucceeded || pipe3DEnabled;
+  const exportEnabled =
+    exportHydroCADEnabled || exportShapefilesEnabled || exportSWMMEnabled;
+
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' as const }]);
   }, []);
@@ -759,10 +765,6 @@ const App: React.FC = () => {
 
   const handleExportSWMM = useCallback(async () => {
     const daLayer = layers.find(l => l.name === 'Drainage Areas');
-    if (!daLayer) {
-      addLog('Drainage Areas layer not found', 'error');
-      return;
-    }
 
     const template = (
       await import('./export_templates/swmm/SWMM_TEMPLATE.inp?raw')
@@ -822,120 +824,123 @@ const App: React.FC = () => {
     const conduitLines: string[] = [];
     const xsectionLines: string[] = [];
     const coordLines: string[] = [];
+    if (daLayer) {
+      const grouped = new Map<
+        string,
+        { area: number; polygons: number[][][] }
+      >();
 
-    const grouped = new Map<
-      string,
-      { area: number; polygons: number[][][] }
-    >();
-
-    daLayer.geojson.features.forEach((f, i) => {
-      const raw = String((f.properties as any)?.DA_NAME ?? '');
-      const id = sanitizeId(raw, i);
-      const geom = f.geometry;
-      const rings: number[][][] =
-        geom.type === 'Polygon'
-          ? [geom.coordinates[0] as number[][]]
-          : (geom as any).coordinates.map((p: any) => p[0] as number[][]);
-      let outerArea = 0;
-      for (const ring of rings) {
-        outerArea += Math.abs(
-          turfArea({
-            type: 'Feature',
-            geometry: { type: 'Polygon', coordinates: [ring] },
-            properties: {},
-          } as any)
-        );
-      }
-      const a = outerArea * 0.000247105; // acres
-      const entry = grouped.get(id) || { area: 0, polygons: [] };
-      entry.area += a;
-      entry.polygons.push(...rings);
-      grouped.set(id, entry);
-    });
-
-    const closeRing = (ring: number[][]) => {
-      if (ring.length < 3) return ring;
-      const [fx, fy] = ring[0];
-      const [lx, ly] = ring[ring.length - 1];
-      const isClosed = fx === lx && fy === ly;
-      return isClosed ? ring : [...ring, ring[0]];
-    };
-
-    Array.from(grouped.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .forEach(([id, { area: a, polygons }]) => {
-        polygons.sort(
-          (aRing, bRing) =>
-            Math.abs(
-              turfArea({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [bRing] },
-                properties: {},
-              } as any)
-            ) -
-            Math.abs(
-              turfArea({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [aRing] },
-                properties: {},
-              } as any)
-            )
-        );
-        let hasRing = false;
-        polygons.forEach((ring) => {
-          const gj = {
-            type: 'Feature',
-            geometry: { type: 'Polygon', coordinates: [ring] },
-            properties: {},
-          } as any;
-          const cleanedGj = cleanCoords(gj);
-          const rewound = rewind(cleanedGj, { reverse: false });
-          const ringCoords = rewound.geometry.coordinates[0] as number[][];
-          const cleaned = ringCoords.filter(
-            (p, i, arr) =>
-              i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+      daLayer.geojson.features.forEach((f, i) => {
+        const raw = String((f.properties as any)?.DA_NAME ?? '');
+        const id = sanitizeId(raw, i);
+        const geom = f.geometry;
+        const rings: number[][][] =
+          geom.type === 'Polygon'
+            ? [geom.coordinates[0] as number[][]]
+            : (geom as any).coordinates.map((p: any) => p[0] as number[][]);
+        let outerArea = 0;
+        for (const ring of rings) {
+          outerArea += Math.abs(
+            turfArea({
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [ring] },
+              properties: {},
+            } as any)
           );
-          const dedup = uniq(cleaned);
-          if (dedup.length < 3) {
-            addLog(`[POLYGONS] anillo degenerado en ${id}`, 'warn');
-            return;
-          }
-          let ringToWrite = dedup;
-          try {
-            if (
-              kinks({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [dedup] },
-                properties: {},
-              } as any).features.length
-            ) {
-              ringToWrite = reorderByAngle(dedup);
-            }
-          } catch {}
-          const closed = closeRing(ringToWrite);
-          const safeClosed = closed.filter(isFinitePair);
-          const projectedRing = safeClosed.map((p) => project.forward(p as [number, number]));
-          if (projectedRing.length < 4) {
-            addLog(
-              `[POLYGONS] Se descartó un anillo degenerado de ${id}`,
-              'warn'
-            );
-            return;
-          }
-          projectedRing.forEach(([x, y]) => {
-            polygonLines.push(`${id}\t${x}\t${y}`);
-          });
-          hasRing = true;
-        });
-        if (hasRing) {
-          const width = a * 100; // simple width approximation
-          subcatchLines.push(
-            `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
-          );
-          subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
-          infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
         }
+        const a = outerArea * 0.000247105; // acres
+        const entry = grouped.get(id) || { area: 0, polygons: [] };
+        entry.area += a;
+        entry.polygons.push(...rings);
+        grouped.set(id, entry);
       });
+
+      const closeRing = (ring: number[][]) => {
+        if (ring.length < 3) return ring;
+        const [fx, fy] = ring[0];
+        const [lx, ly] = ring[ring.length - 1];
+        const isClosed = fx === lx && fy === ly;
+        return isClosed ? ring : [...ring, ring[0]];
+      };
+
+      Array.from(grouped.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .forEach(([id, { area: a, polygons }]) => {
+          polygons.sort(
+            (aRing, bRing) =>
+              Math.abs(
+                turfArea({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [bRing] },
+                  properties: {},
+                } as any)
+              ) -
+              Math.abs(
+                turfArea({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [aRing] },
+                  properties: {},
+                } as any)
+              )
+          );
+          let hasRing = false;
+          polygons.forEach((ring) => {
+            const gj = {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [ring] },
+              properties: {},
+            } as any;
+            const cleanedGj = cleanCoords(gj);
+            const rewound = rewind(cleanedGj, { reverse: false });
+            const ringCoords = rewound.geometry.coordinates[0] as number[][];
+            const cleaned = ringCoords.filter(
+              (p, i, arr) =>
+                i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+            );
+            const dedup = uniq(cleaned);
+            if (dedup.length < 3) {
+              addLog(`[POLYGONS] anillo degenerado en ${id}`, 'warn');
+              return;
+            }
+            let ringToWrite = dedup;
+            try {
+              if (
+                kinks({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [dedup] },
+                  properties: {},
+                } as any).features.length
+              ) {
+                ringToWrite = reorderByAngle(dedup);
+              }
+            } catch {}
+            const closed = closeRing(ringToWrite);
+            const safeClosed = closed.filter(isFinitePair);
+            const projectedRing = safeClosed.map((p) =>
+              project.forward(p as [number, number])
+            );
+            if (projectedRing.length < 4) {
+              addLog(
+                `[POLYGONS] Se descartó un anillo degenerado de ${id}`,
+                'warn'
+              );
+              return;
+            }
+            projectedRing.forEach(([x, y]) => {
+              polygonLines.push(`${id}\t${x}\t${y}`);
+            });
+            hasRing = true;
+          });
+          if (hasRing) {
+            const width = a * 100; // simple width approximation
+            subcatchLines.push(
+              `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
+            );
+            subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
+            infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
+          }
+        });
+    }
 
     const bad = polygonLines.find(
       (l) => l.trim().split(/\s+/).length !== 3
@@ -986,6 +991,7 @@ const App: React.FC = () => {
     const pLayer = layers.find((l) => l.name === 'Pipes');
 
     const nodes: { id: string; coord: [number, number]; invert: number }[] = [];
+    const nodeById = new Map<string, { id: string; coord: [number, number]; invert: number }>();
 
     if (jLayer) {
       const jMap = jLayer.fieldMap;
@@ -996,20 +1002,9 @@ const App: React.FC = () => {
         const ground = Number(
           getMapped(f.properties, jMap, 'ground', ['Elevation Ground [ft]']) ?? 0
         );
-        const invN = Number(
-          getMapped(f.properties, jMap, 'inv_n', ['Invert N [ft]']) ?? 0
+        const invert = Number(
+          getMapped(f.properties, jMap, 'invert', ['Inv Out [ft]']) ?? 0
         );
-        const invS = Number(
-          getMapped(f.properties, jMap, 'inv_s', ['Invert S [ft]']) ?? 0
-        );
-        const invE = Number(
-          getMapped(f.properties, jMap, 'inv_e', ['Invert E [ft]']) ?? 0
-        );
-        const invW = Number(
-          getMapped(f.properties, jMap, 'inv_w', ['Invert W [ft]']) ?? 0
-        );
-        const invCandidates = [invN, invS, invE, invW].filter((v) => v !== 0);
-        const invert = invCandidates.length ? Math.min(...invCandidates) : 0;
         const maxDepth = ground - invert;
         const coord = project.forward(
           (f.geometry as any).coordinates as [number, number]
@@ -1021,7 +1016,9 @@ const App: React.FC = () => {
           junctionLines.push(`${id}\t${invert}\t${maxDepth}\t0\t0\t0`);
         }
         coordLines.push(`${id}\t${coord[0]}\t${coord[1]}`);
-        nodes.push({ id, coord, invert });
+        const node = { id, coord, invert };
+        nodes.push(node);
+        nodeById.set(id, node);
       });
     }
 
@@ -1057,10 +1054,24 @@ const App: React.FC = () => {
         const raw = String(getMapped(f.properties, pMap, 'label', ['Label']) ?? '');
         const id = sanitizeId(raw, i);
         const coords = f.geometry.coordinates as number[][];
-        const start = project.forward(coords[0] as [number, number]);
-        const end = project.forward(coords[coords.length - 1] as [number, number]);
-        const from = findNearestNode(start);
-        const to = findNearestNode(end);
+        const directions = String(
+          getMapped(f.properties, pMap, 'directions', ['Directions']) ?? ''
+        );
+        let from: { id: string; coord: [number, number]; invert: number } | undefined;
+        let to: { id: string; coord: [number, number]; invert: number } | undefined;
+        const dirMatch = directions.match(/(.+?)\s+to\s+(.+)/i);
+        if (dirMatch) {
+          const fromId = sanitizeId(dirMatch[1], 0);
+          const toId = sanitizeId(dirMatch[2], 0);
+          from = nodeById.get(fromId);
+          to = nodeById.get(toId);
+        }
+        if (!from || !to) {
+          const start = project.forward(coords[0] as [number, number]);
+          const end = project.forward(coords[coords.length - 1] as [number, number]);
+          from = from ?? findNearestNode(start);
+          to = to ?? findNearestNode(end);
+        }
         const len = lineLength(coords);
         const rough = Number(
           getMapped(f.properties, pMap, 'roughness', ['Rougness', 'Roughness']) ?? 0
@@ -1547,7 +1558,7 @@ const App: React.FC = () => {
       <Header
         computeEnabled={computeEnabled}
         onCompute={handleCompute}
-        exportEnabled={computeSucceeded}
+        exportEnabled={exportEnabled}
         onExport={() => setExportModalOpen(true)}
         onView3D={handleView3D}
         view3DEnabled={pipe3DEnabled}
@@ -1619,7 +1630,9 @@ const App: React.FC = () => {
           onExportSWMM={handleExportSWMM}
           onExportShapefiles={handleExportShapefiles}
           onClose={() => setExportModalOpen(false)}
-          exportEnabled={computeSucceeded}
+          exportHydroCADEnabled={exportHydroCADEnabled}
+          exportSWMMEnabled={exportSWMMEnabled}
+          exportShapefilesEnabled={exportShapefilesEnabled}
           projection={projection}
           onProjectionChange={(epsg) => {
             const proj = STATE_PLANE_OPTIONS.find(p => p.epsg === epsg);

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -7,12 +7,14 @@ interface ExportModalProps {
   onExportSWMM: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
-  exportEnabled?: boolean;
+  exportHydroCADEnabled?: boolean;
+  exportSWMMEnabled?: boolean;
+  exportShapefilesEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled, projection, onProjectionChange }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -56,30 +58,36 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
         </div>
         <button
           onClick={onExportHydroCAD}
-          disabled={!exportEnabled}
+          disabled={!exportHydroCADEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportHydroCADEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to HydroCAD
         </button>
         <button
           onClick={onExportSWMM}
-          disabled={!exportEnabled}
+          disabled={!exportSWMMEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportSWMMEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to SWMM
         </button>
         <button
           onClick={onExportShapefiles}
-          disabled={!exportEnabled}
+          disabled={!exportShapefilesEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportShapefilesEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export processed shapefiles

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,16 +61,16 @@ const Header: React.FC<HeaderProps> = ({
         <button
           onClick={onView3D}
           disabled={!view3DEnabled}
-          className={
-            'font-semibold px-4 py-1 rounded ' +
-            (view3DEnabled
-              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-          }
-        >
-          3D PIPE NETWORK
-        </button>
-      </div>
+        className={
+          'font-semibold px-4 py-1 rounded ' +
+          (view3DEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        3D Pipe Network
+      </button>
+    </div>
       <div className="absolute right-4 flex items-center space-x-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- Rename 3D viewer button to "3D Pipe Network"
- Enable SWMM export when a pipe network is loaded and gate other exports on compute results
- Include drainage areas, junctions, and conduits in generated SWMM .inp when present
- Map junction and conduit attributes from pipe network fields, honoring Directions connections

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b8d922c83209c5c6d25016d29c6