### PR TITLE
Enable SWMM export for pipe network

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -7,12 +7,14 @@ interface ExportModalProps {
   onExportSWMM: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
-  exportEnabled?: boolean;
+  exportHydroCADEnabled?: boolean;
+  exportSWMMEnabled?: boolean;
+  exportShapefilesEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled, projection, onProjectionChange }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -56,30 +58,36 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
         </div>
         <button
           onClick={onExportHydroCAD}
-          disabled={!exportEnabled}
+          disabled={!exportHydroCADEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportHydroCADEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to HydroCAD
         </button>
         <button
           onClick={onExportSWMM}
-          disabled={!exportEnabled}
+          disabled={!exportSWMMEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportSWMMEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to SWMM
         </button>
         <button
           onClick={onExportShapefiles}
-          disabled={!exportEnabled}
+          disabled={!exportShapefilesEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportShapefilesEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export processed shapefiles

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,16 +61,16 @@ const Header: React.FC<HeaderProps> = ({
         <button
           onClick={onView3D}
           disabled={!view3DEnabled}
-          className={
-            'font-semibold px-4 py-1 rounded ' +
-            (view3DEnabled
-              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-          }
-        >
-          3D PIPE NETWORK
-        </button>
-      </div>
+        className={
+          'font-semibold px-4 py-1 rounded ' +
+          (view3DEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        3D Pipe Network
+      </button>
+    </div>
       <div className="absolute right-4 flex items-center space-x-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- Rename 3D viewer button to "3D Pipe Network"
- Enable SWMM export when a pipe network is loaded and gate other exports on compute results
- Include drainage areas, junctions, and conduits in generated SWMM .inp when present
- Map junction elevations and pipe connections from pipe attributes for accurate SWMM network

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b8d922c83209c5c6d25016d29c6