### PR TITLE
Enable SWMM export for pipe network

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -63,6 +63,7 @@ const App: React.FC = () => {
   const [projectVersion, setProjectVersion] = useState<string>('V1');
   const [exportModalOpen, setExportModalOpen] = useState<boolean>(false);
   const [projection, setProjection] = useState<ProjectionOption>(STATE_PLANE_OPTIONS[0]);
+  const [projectionConfirmed, setProjectionConfirmed] = useState<boolean>(false);
 
   const requiredLayers = [
     'Drainage Areas',
@@ -89,6 +90,11 @@ const App: React.FC = () => {
     cbLayer.geojson.features.length > 0 &&
     !!pipesLayer &&
     pipesLayer.geojson.features.length > 0;
+
+  const exportHydroCADEnabled = computeSucceeded;
+  const exportShapefilesEnabled = computeSucceeded && projectionConfirmed;
+  const exportSWMMEnabled = (computeSucceeded || pipe3DEnabled) && projectionConfirmed;
+  const exportEnabled = computeSucceeded || pipe3DEnabled;
 
   const addLog = useCallback((message: string, type: 'info' | 'error' = 'info') => {
     setLogs(prev => [...prev, { message, type, source: 'frontend' as const }]);
@@ -233,9 +239,14 @@ const App: React.FC = () => {
           let invIn = fieldMap.inv_in && props[fieldMap.inv_in] !== undefined ? Number(props[fieldMap.inv_in]) : null;
           let invOut = fieldMap.inv_out && props[fieldMap.inv_out] !== undefined ? Number(props[fieldMap.inv_out]) : null;
           let direction: string | null = null;
+          if (fieldMap.direction && props[fieldMap.direction] != null) {
+            direction = String(props[fieldMap.direction]);
+          } else if ((props as any)['Directions']) {
+            direction = String((props as any)['Directions']);
+          }
           let inletOffset: number | null = null;
           let outletOffset: number | null = null;
-          if (f.geometry && f.geometry.type === 'LineString' && cbFeatures.length) {
+          if (!direction && f.geometry && f.geometry.type === 'LineString' && cbFeatures.length) {
             const coords = f.geometry.coordinates as number[][];
             const start = coords[0] as [number, number];
             const end = coords[coords.length - 1] as [number, number];
@@ -314,8 +325,13 @@ const App: React.FC = () => {
           const invS = getInv('inv_s');
           const invE = getInv('inv_e');
           const invW = getInv('inv_w');
-          const invs = [invN, invS, invE, invW].filter((v): v is number => v !== null);
-          const invOut = invs.length ? Math.min(...invs) : null;
+          let invOut = fieldMap.inv_out && props[fieldMap.inv_out] !== undefined
+            ? Number((props as any)[fieldMap.inv_out])
+            : null;
+          if (invOut === null || isNaN(invOut)) {
+            const invs = [invN, invS, invE, invW].filter((v): v is number => v !== null);
+            invOut = invs.length ? Math.min(...invs) : null;
+          }
           const ground =
             fieldMap.ground && props[fieldMap.ground] !== undefined
               ? Number((props as any)[fieldMap.ground]) || null
@@ -759,10 +775,6 @@ const App: React.FC = () => {
 
   const handleExportSWMM = useCallback(async () => {
     const daLayer = layers.find(l => l.name === 'Drainage Areas');
-    if (!daLayer) {
-      addLog('Drainage Areas layer not found', 'error');
-      return;
-    }
 
     const template = (
       await import('./export_templates/swmm/SWMM_TEMPLATE.inp?raw')
@@ -822,120 +834,123 @@ const App: React.FC = () => {
     const conduitLines: string[] = [];
     const xsectionLines: string[] = [];
     const coordLines: string[] = [];
+    if (daLayer) {
+      const grouped = new Map<
+        string,
+        { area: number; polygons: number[][][] }
+      >();
 
-    const grouped = new Map<
-      string,
-      { area: number; polygons: number[][][] }
-    >();
-
-    daLayer.geojson.features.forEach((f, i) => {
-      const raw = String((f.properties as any)?.DA_NAME ?? '');
-      const id = sanitizeId(raw, i);
-      const geom = f.geometry;
-      const rings: number[][][] =
-        geom.type === 'Polygon'
-          ? [geom.coordinates[0] as number[][]]
-          : (geom as any).coordinates.map((p: any) => p[0] as number[][]);
-      let outerArea = 0;
-      for (const ring of rings) {
-        outerArea += Math.abs(
-          turfArea({
-            type: 'Feature',
-            geometry: { type: 'Polygon', coordinates: [ring] },
-            properties: {},
-          } as any)
-        );
-      }
-      const a = outerArea * 0.000247105; // acres
-      const entry = grouped.get(id) || { area: 0, polygons: [] };
-      entry.area += a;
-      entry.polygons.push(...rings);
-      grouped.set(id, entry);
-    });
-
-    const closeRing = (ring: number[][]) => {
-      if (ring.length < 3) return ring;
-      const [fx, fy] = ring[0];
-      const [lx, ly] = ring[ring.length - 1];
-      const isClosed = fx === lx && fy === ly;
-      return isClosed ? ring : [...ring, ring[0]];
-    };
-
-    Array.from(grouped.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .forEach(([id, { area: a, polygons }]) => {
-        polygons.sort(
-          (aRing, bRing) =>
-            Math.abs(
-              turfArea({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [bRing] },
-                properties: {},
-              } as any)
-            ) -
-            Math.abs(
-              turfArea({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [aRing] },
-                properties: {},
-              } as any)
-            )
-        );
-        let hasRing = false;
-        polygons.forEach((ring) => {
-          const gj = {
-            type: 'Feature',
-            geometry: { type: 'Polygon', coordinates: [ring] },
-            properties: {},
-          } as any;
-          const cleanedGj = cleanCoords(gj);
-          const rewound = rewind(cleanedGj, { reverse: false });
-          const ringCoords = rewound.geometry.coordinates[0] as number[][];
-          const cleaned = ringCoords.filter(
-            (p, i, arr) =>
-              i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+      daLayer.geojson.features.forEach((f, i) => {
+        const raw = String((f.properties as any)?.DA_NAME ?? '');
+        const id = sanitizeId(raw, i);
+        const geom = f.geometry;
+        const rings: number[][][] =
+          geom.type === 'Polygon'
+            ? [geom.coordinates[0] as number[][]]
+            : (geom as any).coordinates.map((p: any) => p[0] as number[][]);
+        let outerArea = 0;
+        for (const ring of rings) {
+          outerArea += Math.abs(
+            turfArea({
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [ring] },
+              properties: {},
+            } as any)
           );
-          const dedup = uniq(cleaned);
-          if (dedup.length < 3) {
-            addLog(`[POLYGONS] anillo degenerado en ${id}`, 'warn');
-            return;
-          }
-          let ringToWrite = dedup;
-          try {
-            if (
-              kinks({
-                type: 'Feature',
-                geometry: { type: 'Polygon', coordinates: [dedup] },
-                properties: {},
-              } as any).features.length
-            ) {
-              ringToWrite = reorderByAngle(dedup);
-            }
-          } catch {}
-          const closed = closeRing(ringToWrite);
-          const safeClosed = closed.filter(isFinitePair);
-          const projectedRing = safeClosed.map((p) => project.forward(p as [number, number]));
-          if (projectedRing.length < 4) {
-            addLog(
-              `[POLYGONS] Se descartó un anillo degenerado de ${id}`,
-              'warn'
-            );
-            return;
-          }
-          projectedRing.forEach(([x, y]) => {
-            polygonLines.push(`${id}\t${x}\t${y}`);
-          });
-          hasRing = true;
-        });
-        if (hasRing) {
-          const width = a * 100; // simple width approximation
-          subcatchLines.push(
-            `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
-          );
-          subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
-          infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
         }
+        const a = outerArea * 0.000247105; // acres
+        const entry = grouped.get(id) || { area: 0, polygons: [] };
+        entry.area += a;
+        entry.polygons.push(...rings);
+        grouped.set(id, entry);
       });
+
+      const closeRing = (ring: number[][]) => {
+        if (ring.length < 3) return ring;
+        const [fx, fy] = ring[0];
+        const [lx, ly] = ring[ring.length - 1];
+        const isClosed = fx === lx && fy === ly;
+        return isClosed ? ring : [...ring, ring[0]];
+      };
+
+      Array.from(grouped.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .forEach(([id, { area: a, polygons }]) => {
+          polygons.sort(
+            (aRing, bRing) =>
+              Math.abs(
+                turfArea({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [bRing] },
+                  properties: {},
+                } as any)
+              ) -
+              Math.abs(
+                turfArea({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [aRing] },
+                  properties: {},
+                } as any)
+              )
+          );
+          let hasRing = false;
+          polygons.forEach((ring) => {
+            const gj = {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [ring] },
+              properties: {},
+            } as any;
+            const cleanedGj = cleanCoords(gj);
+            const rewound = rewind(cleanedGj, { reverse: false });
+            const ringCoords = rewound.geometry.coordinates[0] as number[][];
+            const cleaned = ringCoords.filter(
+              (p, i, arr) =>
+                i === 0 || p[0] !== arr[i - 1][0] || p[1] !== arr[i - 1][1]
+            );
+            const dedup = uniq(cleaned);
+            if (dedup.length < 3) {
+              addLog(`[POLYGONS] anillo degenerado en ${id}`, 'warn');
+              return;
+            }
+            let ringToWrite = dedup;
+            try {
+              if (
+                kinks({
+                  type: 'Feature',
+                  geometry: { type: 'Polygon', coordinates: [dedup] },
+                  properties: {},
+                } as any).features.length
+              ) {
+                ringToWrite = reorderByAngle(dedup);
+              }
+            } catch {}
+            const closed = closeRing(ringToWrite);
+            const safeClosed = closed.filter(isFinitePair);
+            const projectedRing = safeClosed.map((p) =>
+              project.forward(p as [number, number])
+            );
+            if (projectedRing.length < 4) {
+              addLog(
+                `[POLYGONS] Se descartó un anillo degenerado de ${id}`,
+                'warn'
+              );
+              return;
+            }
+            projectedRing.forEach(([x, y]) => {
+              polygonLines.push(`${id}\t${x}\t${y}`);
+            });
+            hasRing = true;
+          });
+          if (hasRing) {
+            const width = a * 100; // simple width approximation
+            subcatchLines.push(
+              `${id}\t*\t*\t${a.toFixed(4)}\t25\t${width.toFixed(2)}\t0.5\t0`
+            );
+            subareaLines.push(`${id}\t0.01\t0.1\t0.05\t0.05\t25\tOUTLET`);
+            infilLines.push(`${id}\t3\t0.5\t4\t7\t0`);
+          }
+        });
+    }
 
     const bad = polygonLines.find(
       (l) => l.trim().split(/\s+/).length !== 3
@@ -994,22 +1009,17 @@ const App: React.FC = () => {
         const raw = String(getMapped(f.properties, jMap, 'label', ['Label']) ?? '');
         const id = sanitizeId(raw, i);
         const ground = Number(
-          getMapped(f.properties, jMap, 'ground', ['Elevation Ground [ft]']) ?? 0
+          getMapped(f.properties, jMap, 'ground', [
+            'Elevation Ground [ft]',
+            'Elevation Ground [ft]:'
+          ]) ?? 0
         );
-        const invN = Number(
-          getMapped(f.properties, jMap, 'inv_n', ['Invert N [ft]']) ?? 0
+        const invert = Number(
+          getMapped(f.properties, jMap, 'inv_out', [
+            'Inv Out [ft]',
+            'Inv Out [ft]:'
+          ]) ?? 0
         );
-        const invS = Number(
-          getMapped(f.properties, jMap, 'inv_s', ['Invert S [ft]']) ?? 0
-        );
-        const invE = Number(
-          getMapped(f.properties, jMap, 'inv_e', ['Invert E [ft]']) ?? 0
-        );
-        const invW = Number(
-          getMapped(f.properties, jMap, 'inv_w', ['Invert W [ft]']) ?? 0
-        );
-        const invCandidates = [invN, invS, invE, invW].filter((v) => v !== 0);
-        const invert = invCandidates.length ? Math.min(...invCandidates) : 0;
         const maxDepth = ground - invert;
         const coord = project.forward(
           (f.geometry as any).coordinates as [number, number]
@@ -1057,10 +1067,24 @@ const App: React.FC = () => {
         const raw = String(getMapped(f.properties, pMap, 'label', ['Label']) ?? '');
         const id = sanitizeId(raw, i);
         const coords = f.geometry.coordinates as number[][];
-        const start = project.forward(coords[0] as [number, number]);
-        const end = project.forward(coords[coords.length - 1] as [number, number]);
-        const from = findNearestNode(start);
-        const to = findNearestNode(end);
+        const dirStr = String(
+          getMapped(f.properties, pMap, 'direction', ['Directions']) ?? ''
+        );
+        let from: typeof nodes[number] | undefined;
+        let to: typeof nodes[number] | undefined;
+        if (dirStr.includes(' to ')) {
+          const [a, b] = dirStr.split(/\s+to\s+/);
+          const fromId = sanitizeId(a, 0);
+          const toId = sanitizeId(b, 0);
+          from = nodes.find((n) => n.id === fromId);
+          to = nodes.find((n) => n.id === toId);
+        }
+        if (!from || !to) {
+          const start = project.forward(coords[0] as [number, number]);
+          const end = project.forward(coords[coords.length - 1] as [number, number]);
+          from = findNearestNode(start);
+          to = findNearestNode(end);
+        }
         const len = lineLength(coords);
         const rough = Number(
           getMapped(f.properties, pMap, 'roughness', ['Rougness', 'Roughness']) ?? 0
@@ -1547,8 +1571,11 @@ const App: React.FC = () => {
       <Header
         computeEnabled={computeEnabled}
         onCompute={handleCompute}
-        exportEnabled={computeSucceeded}
-        onExport={() => setExportModalOpen(true)}
+        exportEnabled={exportEnabled}
+        onExport={() => {
+          setProjectionConfirmed(false);
+          setExportModalOpen(true);
+        }}
         onView3D={handleView3D}
         view3DEnabled={pipe3DEnabled}
         projectName={projectName}
@@ -1619,12 +1646,19 @@ const App: React.FC = () => {
           onExportSWMM={handleExportSWMM}
           onExportShapefiles={handleExportShapefiles}
           onClose={() => setExportModalOpen(false)}
-          exportEnabled={computeSucceeded}
+          exportHydroCADEnabled={exportHydroCADEnabled}
+          exportSWMMEnabled={exportSWMMEnabled}
+          exportShapefilesEnabled={exportShapefilesEnabled}
           projection={projection}
+          projectionConfirmed={projectionConfirmed}
           onProjectionChange={(epsg) => {
             const proj = STATE_PLANE_OPTIONS.find(p => p.epsg === epsg);
-            if (proj) setProjection(proj);
+            if (proj) {
+              setProjection(proj);
+              setProjectionConfirmed(false);
+            }
           }}
+          onProjectionConfirm={() => setProjectionConfirmed(true)}
         />
       )}
       {mappingLayer && (

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -7,12 +7,16 @@ interface ExportModalProps {
   onExportSWMM: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
-  exportEnabled?: boolean;
+  exportHydroCADEnabled?: boolean;
+  exportSWMMEnabled?: boolean;
+  exportShapefilesEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
+  projectionConfirmed: boolean;
+  onProjectionConfirm: () => void;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportEnabled, projection, onProjectionChange }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, projectionConfirmed, onProjectionConfirm }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -27,7 +31,7 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[2000]">
-      <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-96 space-y-4">
+      <div className="bg-gray-800 p-6 rounded-lg border border-gray-600 w-[30rem] space-y-4">
         <div className="flex justify-between items-center">
           <h2 className="text-lg font-semibold text-white">Export</h2>
           <button className="text-gray-400 hover:text-white" onClick={onClose}>✕</button>
@@ -42,7 +46,7 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
             onChange={(e) => setFilter(e.target.value)}
           />
           <select
-            size={8}
+            size={10}
             className="w-full bg-gray-700 text-white p-2 rounded overflow-y-auto"
             value={projection.epsg}
             onChange={(e) => onProjectionChange(e.target.value)}
@@ -53,33 +57,52 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
               </option>
             ))}
           </select>
+          <div className="flex justify-end mt-2">
+            <button
+              onClick={onProjectionConfirm}
+              className={
+                'px-3 py-1 rounded text-sm font-medium ' +
+                (projectionConfirmed
+                  ? 'bg-green-700 text-white'
+                  : 'bg-cyan-600 hover:bg-cyan-700 text-white')
+              }
+            >
+              {projectionConfirmed ? 'Projection confirmed' : 'Confirm projection'}
+            </button>
+          </div>
         </div>
         <button
           onClick={onExportHydroCAD}
-          disabled={!exportEnabled}
+          disabled={!exportHydroCADEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportHydroCADEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to HydroCAD
         </button>
         <button
           onClick={onExportSWMM}
-          disabled={!exportEnabled}
+          disabled={!exportSWMMEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportSWMMEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export to SWMM
         </button>
         <button
           onClick={onExportShapefiles}
-          disabled={!exportEnabled}
+          disabled={!exportShapefilesEnabled}
           className={
             'w-full font-semibold px-4 py-2 rounded ' +
-            (exportEnabled ? 'bg-cyan-600 hover:bg-cyan-700 text-white' : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+            (exportShapefilesEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
           }
         >
           Export processed shapefiles

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,16 +61,16 @@ const Header: React.FC<HeaderProps> = ({
         <button
           onClick={onView3D}
           disabled={!view3DEnabled}
-          className={
-            'font-semibold px-4 py-1 rounded ' +
-            (view3DEnabled
-              ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
-              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
-          }
-        >
-          3D PIPE NETWORK
-        </button>
-      </div>
+        className={
+          'font-semibold px-4 py-1 rounded ' +
+          (view3DEnabled
+            ? 'bg-cyan-600 hover:bg-cyan-700 text-white cursor-pointer'
+            : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+        }
+      >
+        3D Pipe Network
+      </button>
+    </div>
       <div className="absolute right-4 flex items-center space-x-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- Rename 3D viewer button to "3D Pipe Network"
- Enable SWMM export when a pipe network is loaded and gate other exports on compute results
- Include drainage areas, junctions, and conduits in generated SWMM .inp when present
- Map junction invert and rim elevations from "Inv Out [ft]" and "Elevation Ground [ft]" fields and use pipe "Directions" to connect conduits
- Expand export modal and require users to confirm a projection before SWMM or shapefile exports

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b8d922c83209c5c6d25016d29c6