### PR TITLE
Handle diagonal inverts from catch basins

### DIFF
--- a/components/FieldMapModal.tsx
+++ b/components/FieldMapModal.tsx
@@ -13,7 +13,7 @@ const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, on
     if (layerName === 'Catch Basins / Manholes') {
       const lowerMap = Object.fromEntries(fields.map(f => [f.toLowerCase(), f]));
       const init: Record<string, string> = {};
-      ['inv_n', 'inv_s', 'inv_e', 'inv_w'].forEach(k => {
+      ['inv_n', 'inv_s', 'inv_e', 'inv_w', 'inv_ne', 'inv_se', 'inv_sw', 'inv_nw'].forEach(k => {
         if (lowerMap[k]) init[k] = lowerMap[k];
       });
       return init;
@@ -35,9 +35,13 @@ const FieldMapModal: React.FC<FieldMapModalProps> = ({ layerName, properties, on
       { key: 'label', label: 'Label' },
       { key: 'ground', label: 'Elevation Ground [ft]' },
       { key: 'inv_n', label: 'Invert N [ft]' },
-      { key: 'inv_s', label: 'Invert S [ft]' },
+      { key: 'inv_ne', label: 'Invert NE [ft]' },
       { key: 'inv_e', label: 'Invert E [ft]' },
+      { key: 'inv_se', label: 'Invert SE [ft]' },
+      { key: 'inv_s', label: 'Invert S [ft]' },
+      { key: 'inv_sw', label: 'Invert SW [ft]' },
       { key: 'inv_w', label: 'Invert W [ft]' },
+      { key: 'inv_nw', label: 'Invert NW [ft]' },
     ];
   } else {
     required = [

--- a/tests/direction.test.js
+++ b/tests/direction.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDir } from '../utils/direction.js';
+
+const origin = [0, 0];
+const dest = (deg) => {
+  const rad = deg * Math.PI / 180;
+  // 0° is north, positive clockwise
+  return [Math.sin(rad), Math.cos(rad)];
+};
+
+test('bearing quantization to 8 directions', () => {
+  assert.equal(getDir(origin, dest(30)), 'NE');
+  assert.equal(getDir(origin, dest(120)), 'SE');
+  assert.equal(getDir(origin, dest(210)), 'SW');
+  assert.equal(getDir(origin, dest(300)), 'NW');
+});
+
+test('direction boundary near E/NE', () => {
+  assert.equal(getDir(origin, dest(67)), 'NE');
+  assert.equal(getDir(origin, dest(68)), 'E');
+});

--- a/utils/direction.d.ts
+++ b/utils/direction.d.ts
@@ -1,0 +1,2 @@
+export type Dir8 = 'N'|'NE'|'E'|'SE'|'S'|'SW'|'W'|'NW';
+export function getDir(a: [number, number], b: [number, number]): Dir8;

--- a/utils/direction.js
+++ b/utils/direction.js
@@ -1,0 +1,19 @@
+/**
+ * @typedef {'N'|'NE'|'E'|'SE'|'S'|'SW'|'W'|'NW'} Dir8
+ */
+
+/**
+ * Compute bearing from point a to b and snap to 8 compass directions.
+ * 0° represents North and angles increase clockwise.
+ * @param {[number,number]} a
+ * @param {[number,number]} b
+ * @returns {Dir8}
+ */
+export function getDir(a, b) {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const angle = (Math.atan2(dx, dy) * 180 / Math.PI + 360) % 360;
+  const dirs = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  const idx = Math.round(angle / 45) % 8;
+  return dirs[idx];
+}


### PR DESCRIPTION
## Summary
- Snap pipe bearings to 8 compass directions
- Accept NE/SE/SW/NW invert fields from catch basins
- Compute node invert from directional or Inv Out data and test direction snapping

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68baf96a20608320a54f269665f6cf43