### PR TITLE
feat: export pipe network as LandXML

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -6,17 +6,19 @@ interface ExportModalProps {
   onExportHydroCAD: () => void;
   onExportSWMM: () => void;
   onExportShapefiles: () => void;
+  onExportLandXML: () => void;
   onClose: () => void;
   exportHydroCADEnabled?: boolean;
   exportSWMMEnabled?: boolean;
   exportShapefilesEnabled?: boolean;
+  exportLandXMLEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
   onProjectionConfirm: () => void;
   projectionConfirmed: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onExportLandXML, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, exportLandXMLEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -93,6 +95,18 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
           }
         >
           Export to SWMM
+        </button>
+        <button
+          onClick={onExportLandXML}
+          disabled={!exportLandXMLEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportLandXMLEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export pipe network (LandXML)
         </button>
         <button
           onClick={onExportShapefiles}

--- a/process-file-map.json
+++ b/process-file-map.json
@@ -10,5 +10,9 @@
   "exportShapefiles": {
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []
+  },
+  "exportLandXML": {
+    "requires": ["catchBasinManhole", "pipes"],
+    "excludes": []
   }
 }


### PR DESCRIPTION
## Summary
- add LandXML export handler using pipe and structure data
- expose LandXML export option in the export modal
- document LandXML requirements in process-file-map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bec7ead2108320a2712e7e2700c08f