### PR TITLE
Add LandXML pipe network export

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -96,6 +96,7 @@ const App: React.FC = () => {
   const exportHydroCADEnabled = computeSucceeded;
   const exportShapefilesEnabled = computeSucceeded && projectionConfirmed;
   const exportSWMMEnabled = (computeSucceeded || pipe3DEnabled) && projectionConfirmed;
+  const exportLandXMLEnabled = pipe3DEnabled && projectionConfirmed;
   const exportEnabled = computeSucceeded || pipe3DEnabled;
 
   const splitPipesAtNodes = (
@@ -1371,7 +1372,61 @@ const App: React.FC = () => {
     URL.revokeObjectURL(url);
     addLog('SWMM file exported');
     setExportModalOpen(false);
-    }, [addLog, layers, projectName, projectVersion, projection]);
+  }, [addLog, layers, projectName, projectVersion, projection]);
+
+  const handleExportLandXML = useCallback(() => {
+    if (!cbLayer || !pipesLayer) return;
+
+    const cbs = reprojectFeatureCollection(cbLayer.geojson, projection.proj4);
+    const pipes = reprojectFeatureCollection(pipesLayer.geojson, projection.proj4);
+
+    const coordKey = (p: number[]) => `${p[0].toFixed(3)},${p[1].toFixed(3)}`;
+    const nodeMap = new Map<string, string>();
+    const structLines: string[] = [];
+    cbs.features.forEach((f, i) => {
+      if (!f.geometry || f.geometry.type !== 'Point') return;
+      const [x, y] = (f.geometry.coordinates as number[]) || [];
+      const id = `S${i + 1}`;
+      nodeMap.set(coordKey([x, y]), id);
+      structLines.push(
+        `<Struct name="${id}"><Location><Pnt>${i + 1} ${x} ${y} 0</Pnt></Location></Struct>`
+      );
+    });
+
+    const pipeLines: string[] = [];
+    pipes.features.forEach((f, i) => {
+      if (!f.geometry || f.geometry.type !== 'LineString') return;
+      const coords = f.geometry.coordinates as number[][];
+      const start = nodeMap.get(coordKey(coords[0])) || '';
+      const end = nodeMap.get(coordKey(coords[coords.length - 1])) || '';
+      const pts = coords.map(c => `${c[0]} ${c[1]} 0`).join(' ');
+      pipeLines.push(
+        `<Pipe name="P${i + 1}" refStart="${start}" refEnd="${end}"><CenterLine><PntList3D>${pts}</PntList3D></CenterLine></Pipe>`
+      );
+    });
+
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<LandXML xmlns="http://www.landxml.org/schema/LandXML-1.2" version="1.2">\n` +
+      `  <Units><Metric linearUnit="foot"/></Units>\n` +
+      `  <PipeNetworks>\n` +
+      `    <PipeNetwork name="${projectName || 'Pipe Network'}">\n` +
+      `      <Structs>\n        ${structLines.join('\n        ')}\n      </Structs>\n` +
+      `      <Pipes>\n        ${pipeLines.join('\n        ')}\n      </Pipes>\n` +
+      `    </PipeNetwork>\n` +
+      `  </PipeNetworks>\n` +
+      `</LandXML>`;
+
+    const blob = new Blob([xml], { type: 'application/xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${projectName || 'project'}_${projectVersion}_pipe_network.xml`;
+    a.click();
+    URL.revokeObjectURL(url);
+    addLog('LandXML file exported');
+    setExportModalOpen(false);
+  }, [addLog, cbLayer, pipesLayer, projectName, projectVersion, projection]);
 
   const handleExportShapefiles = useCallback(async () => {
     const processedLayers = layers.filter(
@@ -1818,10 +1873,12 @@ const App: React.FC = () => {
         <ExportModal
           onExportHydroCAD={handleExportHydroCAD}
           onExportSWMM={handleExportSWMM}
+          onExportLandXML={handleExportLandXML}
           onExportShapefiles={handleExportShapefiles}
           onClose={() => setExportModalOpen(false)}
           exportHydroCADEnabled={exportHydroCADEnabled}
           exportSWMMEnabled={exportSWMMEnabled}
+          exportLandXMLEnabled={exportLandXMLEnabled}
           exportShapefilesEnabled={exportShapefilesEnabled}
           projection={projection}
           onProjectionChange={(epsg) => {

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -5,10 +5,12 @@ import type { ProjectionOption } from '../types';
 interface ExportModalProps {
   onExportHydroCAD: () => void;
   onExportSWMM: () => void;
+  onExportLandXML: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
   exportHydroCADEnabled?: boolean;
   exportSWMMEnabled?: boolean;
+  exportLandXMLEnabled?: boolean;
   exportShapefilesEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
@@ -16,7 +18,7 @@ interface ExportModalProps {
   projectionConfirmed: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportLandXML, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportLandXMLEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -93,6 +95,18 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
           }
         >
           Export to SWMM
+        </button>
+        <button
+          onClick={onExportLandXML}
+          disabled={!exportLandXMLEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportLandXMLEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export to LandXML
         </button>
         <button
           onClick={onExportShapefiles}

--- a/export_templates/README.md
+++ b/export_templates/README.md
@@ -3,3 +3,6 @@ This directory holds example templates for exporting results to various software
 `hydrocad` contains sample files demonstrating the expected structure for HydroCAD.
 
 `swmm` contains sample files demonstrating the expected structure for SWMM.
+
+LandXML pipe network exports are generated directly from project data and do not require a template.
+

--- a/process-file-map.json
+++ b/process-file-map.json
@@ -7,6 +7,10 @@
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []
   },
+  "exportLandXML": {
+    "requires": ["catchBasinManhole", "pipes"],
+    "excludes": []
+  },
   "exportShapefiles": {
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []


### PR DESCRIPTION
## Summary
- add LandXML export option alongside HydroCAD, SWMM, and shapefiles
- build LandXML from reprojected pipes and structures
- document LandXML export in templates readme and process file map

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec7ead2108320a2712e7e2700c08f