### PR TITLE
feat: add LandXML pipe network export

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -96,6 +96,7 @@ const App: React.FC = () => {
   const exportHydroCADEnabled = computeSucceeded;
   const exportShapefilesEnabled = computeSucceeded && projectionConfirmed;
   const exportSWMMEnabled = (computeSucceeded || pipe3DEnabled) && projectionConfirmed;
+  const exportLandXMLEnabled = pipe3DEnabled && projectionConfirmed;
   const exportEnabled = computeSucceeded || pipe3DEnabled;
 
   const splitPipesAtNodes = (
@@ -1371,7 +1372,144 @@ const App: React.FC = () => {
     URL.revokeObjectURL(url);
     addLog('SWMM file exported');
     setExportModalOpen(false);
-    }, [addLog, layers, projectName, projectVersion, projection]);
+  }, [addLog, layers, projectName, projectVersion, projection]);
+
+  const handleExportLandXML = useCallback(() => {
+    const jLayer = layers.find(l => l.name === 'Catch Basins / Manholes');
+    const pLayer = layers.find(l => l.name === 'Pipes');
+    if (!jLayer || !pLayer) {
+      addLog('No pipe network data to export', 'error');
+      return;
+    }
+    const projectFn = proj4('EPSG:4326', projection.proj4);
+    const nodeFeatures = jLayer.geojson.features.filter(
+      f => f.geometry && f.geometry.type === 'Point'
+    ) as Feature<Point>[];
+    const nodeKey = (c: number[]) => `${c[0].toFixed(6)},${c[1].toFixed(6)}`;
+    const nodes = nodeFeatures
+      .map((f, i) => {
+        const raw = (f.geometry as Point).coordinates as [number, number];
+        const [x, y] = projectFn.forward(raw);
+        const props = f.properties as any;
+        const ground = parseFloat(props?.['Elevation Ground [ft]']);
+        const invOut = parseFloat(
+          props?.['Inv Out [ft]'] ?? props?.['Elevation Invert[ft]']
+        );
+        if (!isFinite(ground) || !isFinite(invOut)) return null;
+        const id = `N${i + 1}`;
+        return { id, x, y, ground, invOut, key: nodeKey(raw) };
+      })
+      .filter(
+        (n): n is {
+          id: string;
+          x: number;
+          y: number;
+          ground: number;
+          invOut: number;
+          key: string;
+        } => n !== null
+      );
+    const nodeMap = new Map(nodes.map(n => [n.key, n.id]));
+
+    const rawPipeFeatures: Feature<LineString>[] = [];
+    pLayer.geojson.features.forEach(f => {
+      if (!f.geometry) return;
+      if (f.geometry.type === 'LineString') {
+        rawPipeFeatures.push(f as Feature<LineString>);
+      } else if (f.geometry.type === 'MultiLineString') {
+        (f.geometry.coordinates as number[][][]).forEach(coords => {
+          rawPipeFeatures.push({
+            type: 'Feature',
+            geometry: { type: 'LineString', coordinates: coords },
+            properties: f.properties || {},
+          });
+        });
+      }
+    });
+    const pipeFeatures = splitPipesAtNodes(rawPipeFeatures, nodeFeatures);
+    const pipes = pipeFeatures
+      .map((f, i) => {
+        const coords = (f.geometry as LineString).coordinates;
+        const startRaw = coords[0] as [number, number];
+        const endRaw = coords[coords.length - 1] as [number, number];
+        const [sx, sy] = projectFn.forward(startRaw);
+        const [ex, ey] = projectFn.forward(endRaw);
+        const invIn = parseFloat(
+          (f.properties as any)?.['Elevation Invert In [ft]']
+        );
+        const invOut = parseFloat(
+          (f.properties as any)?.['Elevation Invert Out [ft]']
+        );
+        const diam =
+          parseFloat((f.properties as any)?.['Diameter [in]']) / 12;
+        if (![invIn, invOut, diam].every(isFinite)) return null;
+        const id = `P${i + 1}`;
+        return {
+          id,
+          startId: nodeMap.get(nodeKey(startRaw)) || '',
+          endId: nodeMap.get(nodeKey(endRaw)) || '',
+          sx,
+          sy,
+          sz: invIn + diam / 2,
+          ex,
+          ey,
+          ez: invOut + diam / 2,
+          diam,
+        };
+      })
+      .filter(
+        (p): p is {
+          id: string;
+          startId: string;
+          endId: string;
+          sx: number;
+          sy: number;
+          sz: number;
+          ex: number;
+          ey: number;
+          ez: number;
+          diam: number;
+        } => p !== null
+      );
+
+    if (nodes.length === 0 && pipes.length === 0) {
+      addLog('No pipe network data to export', 'error');
+      return;
+    }
+
+    const structLines = nodes.map(
+      n =>
+        `        <Struct name="${n.id}" id="${n.id}">\n          <Center><P x="${n.x.toFixed(
+            3
+          )}" y="${n.y.toFixed(3)}" z="${n.ground.toFixed(
+            3
+          )}"/></Center>\n          <Invert>${n.invOut.toFixed(3)}</Invert>\n        </Struct>`
+    );
+    const pipeLines = pipes.map(
+      p =>
+        `        <Pipe name="${p.id}" id="${p.id}" refStart="${p.startId}" refEnd="${p.endId}" diam="${p.diam.toFixed(
+          3
+        )}">\n          <Geometry>\n            <Line>\n              <PntList3D>${p.sx.toFixed(3)} ${p.sy.toFixed(3)} ${p.sz.toFixed(
+          3
+        )} ${p.ex.toFixed(3)} ${p.ey.toFixed(3)} ${p.ez.toFixed(
+          3
+        )}</PntList3D>\n            </Line>\n          </Geometry>\n        </Pipe>`
+    );
+    const content = `<?xml version="1.0" encoding="UTF-8"?>\n<LandXML xmlns="http://www.landxml.org/schema/LandXML-1.2" version="1.2">\n  <Units>\n    <Imperial linearUnit="foot"/>\n  </Units>\n  <PipeNetworks>\n    <PipeNetwork name="${
+      projectName || 'PipeNetwork'
+    }">\n      <Structs>\n${structLines.join('\n')}\n      </Structs>\n      <Pipes>\n${pipeLines.join('\n')}\n      </Pipes>\n    </PipeNetwork>\n  </PipeNetworks>\n</LandXML>\n`;
+
+    const blob = new Blob([content], { type: 'application/xml' });
+    const filename = `${(projectName || 'project')}_${projectVersion}.xml`;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    addLog('LandXML file exported');
+    setExportModalOpen(false);
+  }, [addLog, layers, projectName, projectVersion, projection]);
 
   const handleExportShapefiles = useCallback(async () => {
     const processedLayers = layers.filter(
@@ -1819,10 +1957,12 @@ const App: React.FC = () => {
           onExportHydroCAD={handleExportHydroCAD}
           onExportSWMM={handleExportSWMM}
           onExportShapefiles={handleExportShapefiles}
+          onExportLandXML={handleExportLandXML}
           onClose={() => setExportModalOpen(false)}
           exportHydroCADEnabled={exportHydroCADEnabled}
           exportSWMMEnabled={exportSWMMEnabled}
           exportShapefilesEnabled={exportShapefilesEnabled}
+          exportLandXMLEnabled={exportLandXMLEnabled}
           projection={projection}
           onProjectionChange={(epsg) => {
             const proj = STATE_PLANE_OPTIONS.find(p => p.epsg === epsg);

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -6,17 +6,19 @@ interface ExportModalProps {
   onExportHydroCAD: () => void;
   onExportSWMM: () => void;
   onExportShapefiles: () => void;
+  onExportLandXML: () => void;
   onClose: () => void;
   exportHydroCADEnabled?: boolean;
   exportSWMMEnabled?: boolean;
   exportShapefilesEnabled?: boolean;
+  exportLandXMLEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
   onProjectionConfirm: () => void;
   projectionConfirmed: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onExportLandXML, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, exportLandXMLEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -93,6 +95,18 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
           }
         >
           Export to SWMM
+        </button>
+        <button
+          onClick={onExportLandXML}
+          disabled={!exportLandXMLEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportLandXMLEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export pipe network (LandXML)
         </button>
         <button
           onClick={onExportShapefiles}

--- a/process-file-map.json
+++ b/process-file-map.json
@@ -7,6 +7,10 @@
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []
   },
+  "exportLandXML": {
+    "requires": ["catchBasinManhole", "pipes"],
+    "excludes": []
+  },
   "exportShapefiles": {
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []


### PR DESCRIPTION
## Summary
- add LandXML export button and handler for pipe networks
- generate LandXML matching 3D viewer coordinates
- document LandXML process requirements

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bec7ead2108320a2712e7e2700c08f