### PR TITLE
Add LandXML pipe network export

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -5,10 +5,12 @@ import type { ProjectionOption } from '../types';
 interface ExportModalProps {
   onExportHydroCAD: () => void;
   onExportSWMM: () => void;
+  onExportLandXML: () => void;
   onExportShapefiles: () => void;
   onClose: () => void;
   exportHydroCADEnabled?: boolean;
   exportSWMMEnabled?: boolean;
+  exportLandXMLEnabled?: boolean;
   exportShapefilesEnabled?: boolean;
   projection: ProjectionOption;
   onProjectionChange: (epsg: string) => void;
@@ -16,7 +18,7 @@ interface ExportModalProps {
   projectionConfirmed: boolean;
 }
 
-const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
+const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportLandXML, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportLandXMLEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
   const [filter, setFilter] = useState('');
 
   const filteredOptions = useMemo(
@@ -93,6 +95,18 @@ const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWM
           }
         >
           Export to SWMM
+        </button>
+        <button
+          onClick={onExportLandXML}
+          disabled={!exportLandXMLEnabled}
+          className={
+            'w-full font-semibold px-4 py-2 rounded ' +
+            (exportLandXMLEnabled
+              ? 'bg-cyan-600 hover:bg-cyan-700 text-white'
+              : 'bg-gray-600 text-gray-300 cursor-not-allowed')
+          }
+        >
+          Export pipe network (LandXML)
         </button>
         <button
           onClick={onExportShapefiles}

--- a/process-file-map.json
+++ b/process-file-map.json
@@ -7,6 +7,10 @@
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []
   },
+  "exportLandXML": {
+    "requires": ["catchBasinManhole", "pipes"],
+    "excludes": []
+  },
   "exportShapefiles": {
     "requires": ["drainageArea", "lod", "landCover", "wss", "catchBasinManhole", "pipes"],
     "excludes": []


### PR DESCRIPTION
## Summary
- add LandXML pipe network export button in export modal
- implement LandXML generation matching 3D viewer coordinates
- document required layers for LandXML export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/direction.test.js`
- `node tests/intersect.test.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec7ead2108320a2712e7e2700c08f