### PR TITLE
feat: add offline projection resolver

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,6 +19,7 @@ import proj4 from 'proj4';
 import { STATE_PLANE_OPTIONS } from './utils/projections';
 import type { ProjectionOption } from './types';
 import { reprojectFeatureCollection } from './utils/reproject';
+import { resolvePrj } from './utils/prj';
 
 const DEFAULT_COLORS: Record<string, string> = {
   'Drainage Areas': '#67e8f9',
@@ -1596,15 +1597,26 @@ const App: React.FC = () => {
     const JSZip = (await import('jszip')).default;
     const shpwrite = (await import('@mapbox/shp-write')).default as any;
     const zip = new JSZip();
+    const prj = await resolvePrj(projection.epsg);
+    if (!prj) {
+      addLog(
+        `Failed to resolve PRJ for EPSG:${projection.epsg}; shapefiles will default to WGS84`,
+        'error'
+      );
+      if (
+        typeof window !== 'undefined' &&
+        !window.confirm(
+          'Projection definition not found; shapefiles will default to WGS84. Continue?'
+        )
+      ) {
+        return;
+      }
+    }
 
     for (const layer of processedLayers) {
       const prepared = prepareForShapefile(layer.geojson, layer.name);
       const projected = reprojectFeatureCollection(prepared, projection.proj4);
       addLog(`Exporting "${layer.name}": ${projected.features.length} features`);
-      let prj: string | undefined;
-      try {
-        prj = await fetch(`https://epsg.io/${projection.epsg}.prj`).then(r => r.text());
-      } catch {}
       const layerZipBuffer = await shpwrite.zip(projected, { outputType: 'arraybuffer', prj });
       const layerZip = await JSZip.loadAsync(layerZipBuffer);
       const folderName = layer.name.replace(/[^a-z0-9_\-]/gi, '_');

--- a/utils/prj.ts
+++ b/utils/prj.ts
@@ -1,0 +1,20 @@
+export const LOCAL_PRJ_BY_EPSG: Record<string, string> = {
+  // EPSG:3857 – WGS 84 / Pseudo-Mercator
+  '3857':
+    'PROJCS["WGS_84_Pseudo_Mercator",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],PARAMETER["Standard_Parallel_1",0],PARAMETER["Auxiliary_Sphere_Type",0],UNIT["Meter",1]]',
+
+  // EJEMPLO: EPSG:2272 – NAD83 / Pennsylvania South (ftUS)
+  '2272':
+    'PROJCS["NAD_1983_StatePlane_Pennsylvania_South_FIPS_3702_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["False_Easting",1968500],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77.75],PARAMETER["Standard_Parallel_1",39.9333333333333],PARAMETER["Standard_Parallel_2",40.9666666666667],PARAMETER["Latitude_Of_Origin",39.3333333333333],UNIT["US_survey_foot",0.3048006096012192],AUTHORITY["EPSG","2272"]]',
+};
+
+export async function resolvePrj(epsg: string): Promise<string | undefined> {
+  if (LOCAL_PRJ_BY_EPSG[epsg]) return LOCAL_PRJ_BY_EPSG[epsg];
+  // Fallback “best effort” (si hay red y CORS lo permite)
+  try {
+    const r = await fetch(`https://epsg.io/${epsg}.prj`);
+    if (r.ok) return await r.text();
+  } catch {}
+  return undefined;
+}
+


### PR DESCRIPTION
## Summary
- add local EPSG map with fallback fetch to resolve PRJ data
- prompt user when projection cannot be resolved before exporting shapefiles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bee1895f48832080e4a972623b91c8