### PR TITLE
Skip truncated projection definitions

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -19,14 +19,19 @@ interface ExportModalProps {
 const ExportModal: React.FC<ExportModalProps> = ({ onExportHydroCAD, onExportSWMM, onExportShapefiles, onClose, exportHydroCADEnabled, exportSWMMEnabled, exportShapefilesEnabled, projection, onProjectionChange, onProjectionConfirm, projectionConfirmed }) => {
   const [filter, setFilter] = useState('');
 
+  const SAFE_OPTIONS = useMemo(
+    () => STATE_PLANE_OPTIONS.filter((o) => !o.proj4.includes('...')),
+    []
+  );
+
   const filteredOptions = useMemo(
     () =>
-      STATE_PLANE_OPTIONS.filter(
+      SAFE_OPTIONS.filter(
         (opt) =>
           opt.name.toLowerCase().includes(filter.toLowerCase()) ||
           opt.epsg.includes(filter)
       ),
-    [filter]
+    [filter, SAFE_OPTIONS]
   );
 
   return (

--- a/utils/prj.ts
+++ b/utils/prj.ts
@@ -29,11 +29,12 @@ export const ESRI_PRJ_BY_EPSG: Record<string, string> = {
 };
 
 export async function resolvePrj(epsg: string): Promise<string> {
-  if (ESRI_PRJ_BY_EPSG[epsg]) return ESRI_PRJ_BY_EPSG[epsg];
-  try {
-    const r = await fetch(`https://epsg.io/${epsg}.prj`);
-    if (r.ok) return await r.text();
-  } catch {}
+  const wkt = ESRI_PRJ_BY_EPSG[epsg];
+  if (wkt && !wkt.includes('...')) return wkt;
+
+  const r = await fetch(`https://epsg.io/${epsg}.prj`);
+  if (r.ok) return await r.text();
+
   throw new Error(`No PRJ found for EPSG:${epsg}`);
 }
 


### PR DESCRIPTION
## Summary
- Ignore local WKT definitions containing `...` and fall back to fetch from epsg.io
- Hide state plane options with incomplete proj4 strings from the export modal

## Testing
- `node --test tests`


------
https://chatgpt.com/codex/tasks/task_e_68bf109f05c08320afd466a90143692d