### PR TITLE
Fix turf intersect calls to pass features directly

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -678,7 +678,9 @@ const App: React.FC = () => {
     setComputeTasks(prev => prev.map(t => t.id === 'check_attrs' ? { ...t, status: 'success' } : t));
 
     try {
-      const { intersect, featureCollection } = await import('@turf/turf');
+      const { intersect: turfIntersect } = await import('@turf/turf');
+      const intersect = (a: Feature | any, b: Feature | any) =>
+        turfIntersect({ type: 'FeatureCollection', features: [a, b] } as any);
       const lodGeom = lod.geojson.features[0];
 
 
@@ -688,8 +690,7 @@ const App: React.FC = () => {
         if (!source) return;
         const clipped: any[] = [];
         source.geojson.features.forEach(f => {
-          const fc = featureCollection([f as any, lodGeom as any]);
-          const inter = intersect(fc as any);
+          const inter = intersect(f as any, lodGeom as any);
           if (inter) {
             inter.properties = { ...(f.properties || {}) };
             clipped.push(inter);
@@ -727,12 +728,10 @@ const App: React.FC = () => {
         const overlay: any[] = [];
         daLayer.geojson.features.forEach(daF => {
           wssLayer.geojson.features.forEach(wssF => {
-            const fc1 = featureCollection([daF as any, wssF as any]);
-            const inter1 = intersect(fc1 as any);
+            const inter1 = intersect(daF as any, wssF as any);
             if (!inter1) return;
             lcLayer.geojson.features.forEach(lcF => {
-              const fc2 = featureCollection([inter1 as any, lcF as any]);
-              const inter2 = intersect(fc2 as any);
+              const inter2 = intersect(inter1 as any, lcF as any);
               if (inter2) {
                 inter2.properties = {
                   ...(daF.properties || {}),


### PR DESCRIPTION
## Summary
- wrap the turf intersect helper so compute steps call it with two features instead of featureCollection wrappers
- update the backend intersect endpoint to accept feature pairs using the same helper approach

## Testing
- node --test tests/intersect.test.js
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca04d233f08320bbb98da93267a219