### PR TITLE
Fix catch basin zero handling

### DIFF
--- a/tests/layerTransforms.test.js
+++ b/tests/layerTransforms.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, writeFile, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { join } from 'node:path';
+import * as ts from 'typescript';
+
+const loadLayerTransforms = async () => {
+  const sourceUrl = new URL('../utils/layerTransforms.ts', import.meta.url);
+  const sourcePath = fileURLToPath(sourceUrl);
+  const tsSource = await readFile(sourcePath, 'utf8');
+  let { outputText } = ts.transpileModule(tsSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2020,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const directionUrl = new URL('../utils/direction.js', import.meta.url);
+  outputText = outputText.replace(/from\s+['"]\.\/direction(?:\.js)?['"]/g, `from '${directionUrl.href}'`);
+
+  const tmpFile = join(tmpdir(), `layerTransforms-${randomUUID()}.mjs`);
+  await writeFile(tmpFile, outputText);
+  try {
+    return await import(pathToFileURL(tmpFile).href);
+  } finally {
+    await unlink(tmpFile).catch(() => {});
+  }
+};
+
+test('catch basin retains zero-valued readings after normalization', async () => {
+  const { transformLayerGeojson } = await loadLayerTransforms();
+
+  const fieldMap = {
+    label: 'Name',
+    inv_n: 'InvN',
+    inv_out: 'InvOut',
+    ground: 'Ground',
+  };
+
+  const geojson = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {
+          Name: 'CB-1',
+          InvN: 0,
+          InvOut: 0,
+          Ground: 0,
+        },
+      },
+    ],
+  };
+
+  const result = transformLayerGeojson('Catch Basins / Manholes', geojson, {
+    landCoverOptions: [],
+    layers: [],
+    fieldMap,
+  });
+
+  const props = result.features[0].properties;
+  assert.strictEqual(props['Invert N [ft]'], 0);
+  assert.strictEqual(props['Inv Out [ft]'], 0);
+  assert.strictEqual(props['Elevation Ground [ft]'], 0);
+});

--- a/utils/layerTransforms.ts
+++ b/utils/layerTransforms.ts
@@ -89,20 +89,20 @@ const preparePipesLayer = (
       NW: 'Invert NW [ft]',
     };
     const val = Number((properties as any)[keyMap[dir]]);
-    if (val && !isNaN(val)) return val;
+    if (Number.isFinite(val)) return val;
     const outVal = Number((properties as any)['Inv Out [ft]']);
-    if (outVal && !isNaN(outVal)) return outVal;
+    if (Number.isFinite(outVal)) return outVal;
     const nodeVal = Number((properties as any)['Elevation Invert[ft]']);
-    return nodeVal && !isNaN(nodeVal) ? nodeVal : null;
+    return Number.isFinite(nodeVal) ? nodeVal : null;
   };
 
   const invOutFromCb = (cb: Feature<Point> | null) => {
     if (!cb) return null;
     const properties = cb.properties || {};
     const val = Number((properties as any)['Elevation Invert[ft]']);
-    if (val && !isNaN(val)) return val;
+    if (Number.isFinite(val)) return val;
     const outVal = Number((properties as any)['Inv Out [ft]']);
-    if (outVal && !isNaN(outVal)) return outVal;
+    if (Number.isFinite(outVal)) return outVal;
     const dirs = [
       'Invert N [ft]',
       'Invert S [ft]',
@@ -215,8 +215,7 @@ const prepareCatchBasinsLayer = (
     const column = fieldMap[columnKey];
     if (!column) return null;
     const value = Number(props[column]);
-    if (!value || value === 0 || isNaN(value)) return null;
-    return value;
+    return Number.isFinite(value) ? value : null;
   };
 
   const features = geojson.features.map(feature => {
@@ -245,10 +244,11 @@ const prepareCatchBasinsLayer = (
       : invCandidates.length
         ? Math.min(...invCandidates)
         : null;
-    const ground =
-      fieldMap.ground && props[fieldMap.ground] !== undefined
-        ? Number(props[fieldMap.ground]) || null
-        : null;
+    let ground: number | null = null;
+    if (fieldMap.ground && props[fieldMap.ground] !== undefined) {
+      const parsed = Number(props[fieldMap.ground]);
+      ground = Number.isFinite(parsed) ? parsed : null;
+    }
 
     return {
       ...feature,


### PR DESCRIPTION
## Summary
- ensure catch basin invert lookups treat zero values as valid
- keep ground elevations of zero intact during catch basin normalization
- add a regression test verifying zero-valued catch basin readings survive transformation

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ccc255815c8320b59ae27cb144d9a9