### PR TITLE
Handle missing catch basin attributes during shapefile export

### DIFF
--- a/tests/exportCatchBasins.test.js
+++ b/tests/exportCatchBasins.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, writeFile, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as ts from 'typescript';
+
+const loadModule = async (relativePath) => {
+  const sourceUrl = new URL(relativePath, import.meta.url);
+  const sourcePath = fileURLToPath(sourceUrl);
+  const tsSource = await readFile(sourcePath, 'utf8');
+  let { outputText } = ts.transpileModule(tsSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2020,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  if (relativePath.endsWith('utils/shp.ts')) {
+    const turfEntry = new URL(
+      '../node_modules/@turf/turf/dist/esm/index.js',
+      import.meta.url
+    );
+    outputText = outputText.replace(
+      /from\s+['"]@turf\/turf['"]/g,
+      `from '${turfEntry.href}'`
+    );
+  }
+  const tmpFile = join(tmpdir(), `export-${randomUUID()}.mjs`);
+  await writeFile(tmpFile, outputText);
+  try {
+    return await import(pathToFileURL(tmpFile).href);
+  } finally {
+    await unlink(tmpFile).catch(() => {});
+  }
+};
+
+test('catch basin export retains features with missing invert data', async () => {
+  const { buildCatchBasinExportData } = await loadModule('../utils/exportCatchBasins.ts');
+  const { prepareForShapefile } = await loadModule('../utils/shp.ts');
+
+  const features = [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        Label: 'CB-1',
+        'Inv Out [ft]': 10,
+        'Elevation Ground [ft]': 12,
+      },
+    },
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [1, 1] },
+      properties: {
+        Label: 'CB-2',
+        'Elevation Ground [ft]': 14,
+      },
+    },
+  ];
+
+  const result = buildCatchBasinExportData({
+    features,
+    fieldMap: undefined,
+    forward: (coord) => coord,
+  });
+
+  assert.equal(result.features.length, features.length);
+  assert.equal(result.nodes.length, 1, 'only complete records contribute nodes');
+
+  const missingProps = result.features[1].properties;
+  assert.ok(Object.prototype.hasOwnProperty.call(missingProps, 'Inv Out [ft]'));
+  assert.strictEqual(missingProps['Inv Out [ft]'], null);
+
+  const prepared = prepareForShapefile(
+    { type: 'FeatureCollection', features: result.features },
+    'Catch Basins / Manholes'
+  );
+
+  assert.equal(prepared.features.length, features.length);
+  const exportedProps = prepared.features[1].properties;
+  const sanitizedKey = 'Inv Out [ft]'.slice(0, 10).replace(/[^A-Za-z0-9_]/g, '_');
+  assert.ok(Object.prototype.hasOwnProperty.call(exportedProps, sanitizedKey));
+  assert.strictEqual(exportedProps[sanitizedKey], null);
+});
+

--- a/utils/exportCatchBasins.ts
+++ b/utils/exportCatchBasins.ts
@@ -1,0 +1,121 @@
+import type { Feature, Point } from 'geojson';
+
+export type CatchBasinNode = {
+  id: string;
+  coord: [number, number];
+  invert: number;
+};
+
+interface CatchBasinExportArgs {
+  features: Feature<Point>[];
+  fieldMap?: Record<string, string>;
+  forward: (coord: [number, number]) => [number, number];
+}
+
+const normalizeKey = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const getPropStrict = (props: any, candidates: string[]) => {
+  if (!props) return undefined;
+  const map = new Map(
+    Object.keys(props).map(key => [normalizeKey(key), key])
+  );
+  for (const cand of candidates) {
+    const hit = map.get(normalizeKey(cand));
+    if (hit !== undefined) return (props as any)[hit];
+  }
+  return undefined;
+};
+
+const getMappedValue = (
+  props: any,
+  map: Record<string, string> | undefined,
+  key: string,
+  candidates: string[]
+) => {
+  if (map && map[key] && props?.[map[key]] !== undefined) {
+    return (props as any)[map[key]];
+  }
+  return getPropStrict(props, candidates);
+};
+
+const sanitizeId = (value: string, index: number) =>
+  (value || `S${index + 1}`)
+    .trim()
+    .replace(/[^\w\-]/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, 31);
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const ensureLabel = (value: unknown, fallback: string) => {
+  if (value === null || value === undefined) return fallback;
+  const str = String(value).trim();
+  return str === '' ? fallback : str;
+};
+
+export const buildCatchBasinExportData = ({
+  features,
+  fieldMap,
+  forward,
+}: CatchBasinExportArgs) => {
+  const nodes: CatchBasinNode[] = [];
+  const exportFeatures: Feature<Point>[] = [];
+
+  features.forEach((feature, index) => {
+    if (!feature.geometry || feature.geometry.type !== 'Point') return;
+
+    const props = feature.properties || {};
+    const rawId = getMappedValue(props, fieldMap, 'label', ['Label']);
+    const id = sanitizeId(rawId != null ? String(rawId) : '', index);
+
+    const invertRaw = getMappedValue(props, fieldMap, 'inv_out', [
+      'Inv Out [ft]',
+      'Inv Out [ft]:',
+      'Elevation Invert[ft]',
+    ]);
+    const groundRaw = getMappedValue(props, fieldMap, 'ground', [
+      'Elevation Ground [ft]',
+    ]);
+
+    const invertVal = toNumberOrNull(invertRaw);
+    const groundVal = toNumberOrNull(groundRaw);
+
+    if (invertVal !== null && groundVal !== null) {
+      const coord = forward(
+        (feature.geometry as Point).coordinates as [number, number]
+      );
+      nodes.push({ id, coord, invert: invertVal });
+    }
+
+    const label = ensureLabel(rawId, id);
+    const roundedInvert = invertVal !== null ? Number(invertVal.toFixed(3)) : null;
+    const roundedGround = groundVal !== null ? Number(groundVal.toFixed(3)) : null;
+
+    const safeProps: Record<string, any> = {
+      ...props,
+      Label: label,
+      'Inv Out [ft]': roundedInvert,
+      'Elevation Ground [ft]': roundedGround,
+    };
+
+    const existingNodeInv = toNumberOrNull(safeProps['Elevation Invert[ft]']);
+    if (existingNodeInv === null) {
+      safeProps['Elevation Invert[ft]'] = roundedInvert;
+    } else {
+      safeProps['Elevation Invert[ft]'] = Number(existingNodeInv.toFixed(3));
+    }
+
+    exportFeatures.push({
+      type: 'Feature',
+      geometry: feature.geometry as Point,
+      properties: safeProps,
+    });
+  });
+
+  return { nodes, features: exportFeatures };
+};
+

--- a/utils/shp.ts
+++ b/utils/shp.ts
@@ -66,7 +66,7 @@ function sanitizeProps(props: GeoJsonProperties, layerName: string): GeoJsonProp
   };
 
   const wl = wlMap[layerName] || Object.keys(props || {});
-  const out: Record<string, number | string> = {};
+  const out: Record<string, number | string | null> = {};
   const used = new Set<string>();
 
   for (const key of wl) {
@@ -74,7 +74,7 @@ function sanitizeProps(props: GeoJsonProperties, layerName: string): GeoJsonProp
     let v = (props as any)[key];
 
     // DBF no admite objetos/arrays -> a string
-    if (typeof v === 'object' && v !== null) v = JSON.stringify(v);
+    if (v !== null && typeof v === 'object') v = JSON.stringify(v);
     if (typeof v === 'string') v = v.slice(0, 254); // límite típico DBF
 
     // Renombra a ≤10 chars, solo [A-Za-z0-9_]
@@ -88,7 +88,7 @@ function sanitizeProps(props: GeoJsonProperties, layerName: string): GeoJsonProp
     used.add(k);
 
     // A DBF sólo number|string; nulls y undefined los saltamos
-    if (typeof v === 'number' || typeof v === 'string') out[k] = v;
+    if (typeof v === 'number' || typeof v === 'string' || v === null) out[k] = v;
   }
 
   return out;


### PR DESCRIPTION
## Summary
- keep catch basin point features during shapefile export by normalizing their IDs and placeholder invert/ground values
- retain null-valued attributes in DBF sanitation so schema keys persist
- add a regression test covering catch basin export when a numeric field is missing

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d15d82777c832092eabee50bd133a3