### PR TITLE
Handle invalid state plane projections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,22 @@
         "@types/node": "^22.14.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "ts-node": "^10.9.2",
         "typescript": "~5.7.2",
         "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -715,6 +729,34 @@
       "integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@mapbox/shp-write": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@mapbox/shp-write/-/shp-write-0.4.3.tgz",
@@ -1025,6 +1067,34 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@turf/along": {
       "version": "7.2.0",
@@ -3142,6 +3212,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -3285,6 +3388,13 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3339,6 +3449,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -3872,6 +3992,13 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/marchingsquares": {
       "version": "1.3.3",
@@ -4619,6 +4746,50 @@
         "geo2topo": "bin/geo2topo"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4682,6 +4853,13 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4772,6 +4950,16 @@
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
       "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
       "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^22.14.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "ts-node": "^10.9.2",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }

--- a/tests/reproject-nad27.test.ts
+++ b/tests/reproject-nad27.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { FeatureCollection, Point } from 'geojson';
+import { reprojectFeatureCollection } from '../utils/reproject';
+import { STATE_PLANE_OPTIONS } from '../utils/statePlaneOptions';
+
+test('NAD27 Alabama East projection yields finite coordinates', () => {
+  const option = STATE_PLANE_OPTIONS.find((opt) => opt.epsg === '26729');
+  assert.ok(option, 'Expected to find NAD27 Alabama East option');
+
+  const sample: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [-86.75, 32.75],
+        },
+        properties: {},
+      },
+    ],
+  };
+
+  const projected = reprojectFeatureCollection(sample, option.proj4);
+  assert.equal(projected.features.length, 1);
+  const coords = (projected.features[0].geometry as Point).coordinates as [number, number];
+  assert.ok(Number.isFinite(coords[0]) && Number.isFinite(coords[1]), 'Projected coordinate should be finite');
+});

--- a/utils/reproject.ts
+++ b/utils/reproject.ts
@@ -3,10 +3,18 @@ import proj4 from 'proj4';
 
 export function reprojectFeatureCollection(fc: FeatureCollection, proj4Def: string): FeatureCollection {
   const project = proj4('EPSG:4326', proj4Def);
+  const forward = (coord: [number, number]): [number, number] => {
+    const [x, y] = project.forward(coord);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      throw new Error(
+        `Projection produced invalid coordinates for ${JSON.stringify(coord)} using definition: ${proj4Def}`
+      );
+    }
+    return [x, y] as [number, number];
+  };
   const reprojectCoords = (coords: any): any => {
     if (typeof coords[0] === 'number') {
-      const [x, y] = project.forward(coords as [number, number]);
-      return [x, y];
+      return forward(coords as [number, number]);
     }
     return coords.map(reprojectCoords);
   };

--- a/utils/statePlaneOptions.ts
+++ b/utils/statePlaneOptions.ts
@@ -10,679 +10,679 @@ export const STATE_PLANE_OPTIONS: ProjectionOption[] = [
   {
     "epsg": "26729",
     "name": "NAD27 / Alabama East",
-    "proj4": "+proj=tmerc +lat_0=30.5 +lon_0=-85.8333333333333 +k=0.99996 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=30.5 +lon_0=-85.8333333333333 +k=0.99996 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26730",
     "name": "NAD27 / Alabama West",
-    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-87.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-87.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26731",
     "name": "NAD27 / Alaska zone 1",
-    "proj4": "+proj=omerc +no_uoff +lat_0=57 +lonc=-133.666666666667 +alpha=323.130102361111 +gamma=323.130102361111 +k=0.9999 +x_0=5000000.001016 +y_0=-5000000.001016 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=omerc +no_uoff +lat_0=57 +lonc=-133.666666666667 +alpha=323.130102361111 +gamma=323.130102361111 +k=0.9999 +x_0=5000000.001016 +y_0=-5000000.001016 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26740",
     "name": "NAD27 / Alaska zone 10",
-    "proj4": "+proj=lcc +lat_0=51 +lon_0=-176 +lat_1=53.8333333333333 +lat_2=51.8333333333333 +x_0=914401.828803657 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=51 +lon_0=-176 +lat_1=53.8333333333333 +lat_2=51.8333333333333 +x_0=914401.828803657 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26732",
     "name": "NAD27 / Alaska zone 2",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-142 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-142 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26733",
     "name": "NAD27 / Alaska zone 3",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-146 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-146 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26734",
     "name": "NAD27 / Alaska zone 4",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-150 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-150 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26735",
     "name": "NAD27 / Alaska zone 5",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-154 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-154 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26736",
     "name": "NAD27 / Alaska zone 6",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-158 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-158 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26737",
     "name": "NAD27 / Alaska zone 7",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-162 +k=0.9999 +x_0=213360.426720853 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-162 +k=0.9999 +x_0=213360.426720853 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26738",
     "name": "NAD27 / Alaska zone 8",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-166 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-166 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26739",
     "name": "NAD27 / Alaska zone 9",
-    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-170 +k=0.9999 +x_0=182880.365760731 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=54 +lon_0=-170 +k=0.9999 +x_0=182880.365760731 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26749",
     "name": "NAD27 / Arizona Central",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-111.916666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-111.916666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26748",
     "name": "NAD27 / Arizona East",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-110.166666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-110.166666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26750",
     "name": "NAD27 / Arizona West",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-113.75 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-113.75 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26751",
     "name": "NAD27 / Arkansas North",
-    "proj4": "+proj=lcc +lat_0=34.3333333333333 +lon_0=-92 +lat_1=36.2333333333333 +lat_2=34.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=34.3333333333333 +lon_0=-92 +lat_1=36.2333333333333 +lat_2=34.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26752",
     "name": "NAD27 / Arkansas South",
-    "proj4": "+proj=lcc +lat_0=32.6666666666667 +lon_0=-92 +lat_1=34.7666666666667 +lat_2=33.3 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=32.6666666666667 +lon_0=-92 +lat_1=34.7666666666667 +lat_2=33.3 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26741",
     "name": "NAD27 / California zone I",
-    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-122 +lat_1=41.6666666666667 +lat_2=40 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-122 +lat_1=41.6666666666667 +lat_2=40 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26742",
     "name": "NAD27 / California zone II",
-    "proj4": "+proj=lcc +lat_0=37.6666666666667 +lon_0=-122 +lat_1=39.8333333333333 +lat_2=38.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=37.6666666666667 +lon_0=-122 +lat_1=39.8333333333333 +lat_2=38.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26743",
     "name": "NAD27 / California zone III",
-    "proj4": "+proj=lcc +lat_0=36.5 +lon_0=-120.5 +lat_1=38.4333333333333 +lat_2=37.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.5 +lon_0=-120.5 +lat_1=38.4333333333333 +lat_2=37.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26744",
     "name": "NAD27 / California zone IV",
-    "proj4": "+proj=lcc +lat_0=35.3333333333333 +lon_0=-119 +lat_1=37.25 +lat_2=36 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=35.3333333333333 +lon_0=-119 +lat_1=37.25 +lat_2=36 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26745",
     "name": "NAD27 / California zone V",
-    "proj4": "+proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26746",
     "name": "NAD27 / California zone VI",
-    "proj4": "+proj=lcc +lat_0=32.1666666666667 +lon_0=-116.25 +lat_1=33.8833333333333 +lat_2=32.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=32.1666666666667 +lon_0=-116.25 +lat_1=33.8833333333333 +lat_2=32.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26799",
     "name": "NAD27 / California zone VII",
-    "proj4": "+proj=lcc +lat_0=34.1333333333333 +lon_0=-118.333333333333 +lat_1=34.4166666666667 +lat_2=33.8666666666667 +x_0=1276106.4505969 +y_0=1268253.00685801 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=34.1333333333333 +lon_0=-118.333333333333 +lat_1=34.4166666666667 +lat_2=33.8666666666667 +x_0=1276106.4505969 +y_0=1268253.00685801 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26754",
     "name": "NAD27 / Colorado Central",
-    "proj4": "+proj=lcc +lat_0=37.8333333333333 +lon_0=-105.5 +lat_1=39.75 +lat_2=38.45 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=37.8333333333333 +lon_0=-105.5 +lat_1=39.75 +lat_2=38.45 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26753",
     "name": "NAD27 / Colorado North",
-    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-105.5 +lat_1=39.7166666666667 +lat_2=40.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-105.5 +lat_1=39.7166666666667 +lat_2=40.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26755",
     "name": "NAD27 / Colorado South",
-    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-105.5 +lat_1=38.4333333333333 +lat_2=37.2333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-105.5 +lat_1=38.4333333333333 +lat_2=37.2333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26758",
     "name": "NAD27 / Florida East",
-    "proj4": "+proj=tmerc +lat_0=24.3333333333333 +lon_0=-81 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=24.3333333333333 +lon_0=-81 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26760",
     "name": "NAD27 / Florida North",
-    "proj4": "+proj=lcc +lat_0=29 +lon_0=-84.5 +lat_1=30.75 +lat_2=29.5833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=29 +lon_0=-84.5 +lat_1=30.75 +lat_2=29.5833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26759",
     "name": "NAD27 / Florida West",
-    "proj4": "+proj=tmerc +lat_0=24.3333333333333 +lon_0=-82 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=24.3333333333333 +lon_0=-82 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26766",
     "name": "NAD27 / Georgia East",
-    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-82.1666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-82.1666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26767",
     "name": "NAD27 / Georgia West",
-    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-84.1666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=30 +lon_0=-84.1666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26769",
     "name": "NAD27 / Idaho Central",
-    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-114 +k=0.999947368 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-114 +k=0.999947368 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26768",
     "name": "NAD27 / Idaho East",
-    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-112.166666666667 +k=0.999947368 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-112.166666666667 +k=0.999947368 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26770",
     "name": "NAD27 / Idaho West",
-    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-115.75 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.6666666666667 +lon_0=-115.75 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26771",
     "name": "NAD27 / Illinois East",
-    "proj4": "+proj=tmerc +lat_0=36.6666666666667 +lon_0=-88.3333333333333 +k=0.999975 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=36.6666666666667 +lon_0=-88.3333333333333 +k=0.999975 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26772",
     "name": "NAD27 / Illinois West",
-    "proj4": "+proj=tmerc +lat_0=36.6666666666667 +lon_0=-90.1666666666667 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=36.6666666666667 +lon_0=-90.1666666666667 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26773",
     "name": "NAD27 / Indiana East",
-    "proj4": "+proj=tmerc +lat_0=37.5 +lon_0=-85.6666666666667 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=37.5 +lon_0=-85.6666666666667 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26774",
     "name": "NAD27 / Indiana West",
-    "proj4": "+proj=tmerc +lat_0=37.5 +lon_0=-87.0833333333333 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=37.5 +lon_0=-87.0833333333333 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26775",
     "name": "NAD27 / Iowa North",
-    "proj4": "+proj=lcc +lat_0=41.5 +lon_0=-93.5 +lat_1=43.2666666666667 +lat_2=42.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=41.5 +lon_0=-93.5 +lat_1=43.2666666666667 +lat_2=42.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26776",
     "name": "NAD27 / Iowa South",
-    "proj4": "+proj=lcc +lat_0=40 +lon_0=-93.5 +lat_1=41.7833333333333 +lat_2=40.6166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=40 +lon_0=-93.5 +lat_1=41.7833333333333 +lat_2=40.6166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26777",
     "name": "NAD27 / Kansas North",
-    "proj4": "+proj=lcc +lat_0=38.3333333333333 +lon_0=-98 +lat_1=39.7833333333333 +lat_2=38.7166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=38.3333333333333 +lon_0=-98 +lat_1=39.7833333333333 +lat_2=38.7166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26778",
     "name": "NAD27 / Kansas South",
-    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-98.5 +lat_1=38.5666666666667 +lat_2=37.2666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-98.5 +lat_1=38.5666666666667 +lat_2=37.2666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26779",
     "name": "NAD27 / Kentucky North",
-    "proj4": "+proj=lcc +lat_0=37.5 +lon_0=-84.25 +lat_1=37.9666666666667 +lat_2=38.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=37.5 +lon_0=-84.25 +lat_1=37.9666666666667 +lat_2=38.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26780",
     "name": "NAD27 / Kentucky South",
-    "proj4": "+proj=lcc +lat_0=36.3333333333333 +lon_0=-85.75 +lat_1=36.7333333333333 +lat_2=37.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.3333333333333 +lon_0=-85.75 +lat_1=36.7333333333333 +lat_2=37.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26781",
     "name": "NAD27 / Louisiana North",
-    "proj4": "+proj=lcc +lat_0=30.6666666666667 +lon_0=-92.5 +lat_1=31.1666666666667 +lat_2=32.6666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=30.6666666666667 +lon_0=-92.5 +lat_1=31.1666666666667 +lat_2=32.6666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26782",
     "name": "NAD27 / Louisiana South",
-    "proj4": "+proj=lcc +lat_0=28.6666666666667 +lon_0=-91.3333333333333 +lat_1=29.3 +lat_2=30.7 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=28.6666666666667 +lon_0=-91.3333333333333 +lat_1=29.3 +lat_2=30.7 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26783",
     "name": "NAD27 / Maine East",
-    "proj4": "+proj=tmerc +lat_0=43.8333333333333 +lon_0=-68.5 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=43.8333333333333 +lon_0=-68.5 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26784",
     "name": "NAD27 / Maine West",
-    "proj4": "+proj=tmerc +lat_0=42.8333333333333 +lon_0=-70.1666666666667 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=42.8333333333333 +lon_0=-70.1666666666667 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "6201",
     "name": "NAD27 / Michigan Central",
-    "proj4": "+proj=lcc +lat_0=43.3166666666667 +lon_0=-84.3333333333333 +lat_1=44.1833333333333 +lat_2=45.7 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=43.3166666666667 +lon_0=-84.3333333333333 +lat_1=44.1833333333333 +lat_2=45.7 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "5623",
     "name": "NAD27 / Michigan East",
-    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-83.6666666666667 +k=0.999942857 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-83.6666666666667 +k=0.999942857 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "6966",
     "name": "NAD27 / Michigan North",
-    "proj4": "+proj=lcc +lat_0=44.7833333333333 +lon_0=-87 +lat_1=45.4833333333333 +lat_2=47.0833333333333 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=44.7833333333333 +lon_0=-87 +lat_1=45.4833333333333 +lat_2=47.0833333333333 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "5624",
     "name": "NAD27 / Michigan Old Central",
-    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-85.75 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-85.75 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "6202",
     "name": "NAD27 / Michigan South",
-    "proj4": "+proj=lcc +lat_0=41.5 +lon_0=-84.3333333333333 +lat_1=42.1 +lat_2=43.6666666666667 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=41.5 +lon_0=-84.3333333333333 +lat_1=42.1 +lat_2=43.6666666666667 +x_0=609601.219202438 +y_0=0 +k_0=1.0000382 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "5625",
     "name": "NAD27 / Michigan West",
-    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-88.75 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=41.5 +lon_0=-88.75 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26792",
     "name": "NAD27 / Minnesota Central",
-    "proj4": "+proj=lcc +lat_0=45 +lon_0=-94.25 +lat_1=45.6166666666667 +lat_2=47.05 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=45 +lon_0=-94.25 +lat_1=45.6166666666667 +lat_2=47.05 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26791",
     "name": "NAD27 / Minnesota North",
-    "proj4": "+proj=lcc +lat_0=46.5 +lon_0=-93.1 +lat_1=47.0333333333333 +lat_2=48.6333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=46.5 +lon_0=-93.1 +lat_1=47.0333333333333 +lat_2=48.6333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26793",
     "name": "NAD27 / Minnesota South",
-    "proj4": "+proj=lcc +lat_0=43 +lon_0=-94 +lat_1=43.7833333333333 +lat_2=45.2166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=43 +lon_0=-94 +lat_1=43.7833333333333 +lat_2=45.2166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26794",
     "name": "NAD27 / Mississippi East",
-    "proj4": "+proj=tmerc +lat_0=29.6666666666667 +lon_0=-88.8333333333333 +k=0.99996 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=29.6666666666667 +lon_0=-88.8333333333333 +k=0.99996 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26795",
     "name": "NAD27 / Mississippi West",
-    "proj4": "+proj=tmerc +lat_0=30.5 +lon_0=-90.3333333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=30.5 +lon_0=-90.3333333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26797",
     "name": "NAD27 / Missouri Central",
-    "proj4": "+proj=tmerc +lat_0=35.8333333333333 +lon_0=-92.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=35.8333333333333 +lon_0=-92.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26796",
     "name": "NAD27 / Missouri East",
-    "proj4": "+proj=tmerc +lat_0=35.8333333333333 +lon_0=-90.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=35.8333333333333 +lon_0=-90.5 +k=0.999933333 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "26798",
     "name": "NAD27 / Missouri West",
-    "proj4": "+proj=tmerc +lat_0=36.1666666666667 +lon_0=-94.5 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=36.1666666666667 +lon_0=-94.5 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32002",
     "name": "NAD27 / Montana Central",
-    "proj4": "+proj=lcc +lat_0=45.8333333333333 +lon_0=-109.5 +lat_1=47.8833333333333 +lat_2=46.45 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=45.8333333333333 +lon_0=-109.5 +lat_1=47.8833333333333 +lat_2=46.45 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32001",
     "name": "NAD27 / Montana North",
-    "proj4": "+proj=lcc +lat_0=47 +lon_0=-109.5 +lat_1=48.7166666666667 +lat_2=47.85 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=47 +lon_0=-109.5 +lat_1=48.7166666666667 +lat_2=47.85 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32003",
     "name": "NAD27 / Montana South",
-    "proj4": "+proj=lcc +lat_0=44 +lon_0=-109.5 +lat_1=46.4 +lat_2=44.8666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=44 +lon_0=-109.5 +lat_1=46.4 +lat_2=44.8666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32005",
     "name": "NAD27 / Nebraska North",
-    "proj4": "+proj=lcc +lat_0=41.3333333333333 +lon_0=-100 +lat_1=41.85 +lat_2=42.8166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=41.3333333333333 +lon_0=-100 +lat_1=41.85 +lat_2=42.8166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32006",
     "name": "NAD27 / Nebraska South",
-    "proj4": "+proj=lcc +lat_0=39.6666666666667 +lon_0=-99.5 +lat_1=40.2833333333333 +lat_2=41.7166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=39.6666666666667 +lon_0=-99.5 +lat_1=40.2833333333333 +lat_2=41.7166666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32008",
     "name": "NAD27 / Nevada Central",
-    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-116.666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-116.666666666667 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32007",
     "name": "NAD27 / Nevada East",
-    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-115.583333333333 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-115.583333333333 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32009",
     "name": "NAD27 / Nevada West",
-    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-118.583333333333 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=34.75 +lon_0=-118.583333333333 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32013",
     "name": "NAD27 / New Mexico Central",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-106.25 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-106.25 +k=0.9999 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32012",
     "name": "NAD27 / New Mexico East",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-104.333333333333 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-104.333333333333 +k=0.999909091 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32014",
     "name": "NAD27 / New Mexico West",
-    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-107.833333333333 +k=0.999916667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=31 +lon_0=-107.833333333333 +k=0.999916667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32016",
     "name": "NAD27 / New York Central",
-    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-76.5833333333333 +k=0.9999375 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-76.5833333333333 +k=0.9999375 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32015",
     "name": "NAD27 / New York East",
-    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-74.3333333333333 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-74.3333333333333 +k=0.999966667 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32017",
     "name": "NAD27 / New York West",
-    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-78.5833333333333 +k=0.9999375 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40 +lon_0=-78.5833333333333 +k=0.9999375 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32019",
     "name": "NAD27 / North Carolina",
-    "proj4": "+proj=lcc +lat_0=33.75 +lon_0=-79 +lat_1=34.3333333333333 +lat_2=36.1666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=33.75 +lon_0=-79 +lat_1=34.3333333333333 +lat_2=36.1666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32020",
     "name": "NAD27 / North Dakota North",
-    "proj4": "+proj=lcc +lat_0=47 +lon_0=-100.5 +lat_1=47.4333333333333 +lat_2=48.7333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=47 +lon_0=-100.5 +lat_1=47.4333333333333 +lat_2=48.7333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32021",
     "name": "NAD27 / North Dakota South",
-    "proj4": "+proj=lcc +lat_0=45.6666666666667 +lon_0=-100.5 +lat_1=46.1833333333333 +lat_2=47.4833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=45.6666666666667 +lon_0=-100.5 +lat_1=46.1833333333333 +lat_2=47.4833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32022",
     "name": "NAD27 / Ohio North",
-    "proj4": "+proj=lcc +lat_0=39.6666666666667 +lon_0=-82.5 +lat_1=40.4333333333333 +lat_2=41.7 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=39.6666666666667 +lon_0=-82.5 +lat_1=40.4333333333333 +lat_2=41.7 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32023",
     "name": "NAD27 / Ohio South",
-    "proj4": "+proj=lcc +lat_0=38 +lon_0=-82.5 +lat_1=38.7333333333333 +lat_2=40.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=38 +lon_0=-82.5 +lat_1=38.7333333333333 +lat_2=40.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32024",
     "name": "NAD27 / Oklahoma North",
-    "proj4": "+proj=lcc +lat_0=35 +lon_0=-98 +lat_1=35.5666666666667 +lat_2=36.7666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=35 +lon_0=-98 +lat_1=35.5666666666667 +lat_2=36.7666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32025",
     "name": "NAD27 / Oklahoma South",
-    "proj4": "+proj=lcc +lat_0=33.3333333333333 +lon_0=-98 +lat_1=33.9333333333333 +lat_2=35.2333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=33.3333333333333 +lon_0=-98 +lat_1=33.9333333333333 +lat_2=35.2333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32026",
     "name": "NAD27 / Oregon North",
-    "proj4": "+proj=lcc +lat_0=43.6666666666667 +lon_0=-120.5 +lat_1=44.3333333333333 +lat_2=46 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=43.6666666666667 +lon_0=-120.5 +lat_1=44.3333333333333 +lat_2=46 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32027",
     "name": "NAD27 / Oregon South",
-    "proj4": "+proj=lcc +lat_0=41.6666666666667 +lon_0=-120.5 +lat_1=42.3333333333333 +lat_2=44 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=41.6666666666667 +lon_0=-120.5 +lat_1=42.3333333333333 +lat_2=44 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32028",
     "name": "NAD27 / Pennsylvania North",
-    "proj4": "+proj=lcc +lat_0=40.1666666666667 +lon_0=-77.75 +lat_1=40.8833333333333 +lat_2=41.95 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=40.1666666666667 +lon_0=-77.75 +lat_1=40.8833333333333 +lat_2=41.95 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "4455",
     "name": "NAD27 / Pennsylvania South",
-    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-77.75 +lat_1=40.9666666666667 +lat_2=39.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=39.3333333333333 +lon_0=-77.75 +lat_1=40.9666666666667 +lat_2=39.9333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32031",
     "name": "NAD27 / South Carolina North",
-    "proj4": "+proj=lcc +lat_0=33 +lon_0=-81 +lat_1=33.7666666666667 +lat_2=34.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=33 +lon_0=-81 +lat_1=33.7666666666667 +lat_2=34.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32033",
     "name": "NAD27 / South Carolina South",
-    "proj4": "+proj=lcc +lat_0=31.8333333333333 +lon_0=-81 +lat_1=32.3333333333333 +lat_2=33.6666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=31.8333333333333 +lon_0=-81 +lat_1=32.3333333333333 +lat_2=33.6666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32034",
     "name": "NAD27 / South Dakota North",
-    "proj4": "+proj=lcc +lat_0=43.8333333333333 +lon_0=-100 +lat_1=44.4166666666667 +lat_2=45.6833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=43.8333333333333 +lon_0=-100 +lat_1=44.4166666666667 +lat_2=45.6833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32035",
     "name": "NAD27 / South Dakota South",
-    "proj4": "+proj=lcc +lat_0=42.3333333333333 +lon_0=-100.333333333333 +lat_1=42.8333333333333 +lat_2=44.4 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=42.3333333333333 +lon_0=-100.333333333333 +lat_1=42.8333333333333 +lat_2=44.4 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32039",
     "name": "NAD27 / Texas Central",
-    "proj4": "+proj=lcc +lat_0=29.6666666666667 +lon_0=-100.333333333333 +lat_1=30.1166666666667 +lat_2=31.8833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=29.6666666666667 +lon_0=-100.333333333333 +lat_1=30.1166666666667 +lat_2=31.8833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32037",
     "name": "NAD27 / Texas North",
-    "proj4": "+proj=lcc +lat_0=34 +lon_0=-101.5 +lat_1=34.65 +lat_2=36.1833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=34 +lon_0=-101.5 +lat_1=34.65 +lat_2=36.1833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32038",
     "name": "NAD27 / Texas North Central",
-    "proj4": "+proj=lcc +lat_0=31.6666666666667 +lon_0=-97.5 +lat_1=32.1333333333333 +lat_2=33.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=31.6666666666667 +lon_0=-97.5 +lat_1=32.1333333333333 +lat_2=33.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32041",
     "name": "NAD27 / Texas South",
-    "proj4": "+proj=lcc +lat_0=25.6666666666667 +lon_0=-98.5 +lat_1=26.1666666666667 +lat_2=27.8333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=25.6666666666667 +lon_0=-98.5 +lat_1=26.1666666666667 +lat_2=27.8333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32040",
     "name": "NAD27 / Texas South Central",
-    "proj4": "+proj=lcc +lat_0=27.8333333333333 +lon_0=-99 +lat_1=28.3833333333333 +lat_2=30.2833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=27.8333333333333 +lon_0=-99 +lat_1=28.3833333333333 +lat_2=30.2833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32043",
     "name": "NAD27 / Utah Central",
-    "proj4": "+proj=lcc +lat_0=38.3333333333333 +lon_0=-111.5 +lat_1=39.0166666666667 +lat_2=40.65 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=38.3333333333333 +lon_0=-111.5 +lat_1=39.0166666666667 +lat_2=40.65 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32042",
     "name": "NAD27 / Utah North",
-    "proj4": "+proj=lcc +lat_0=40.3333333333333 +lon_0=-111.5 +lat_1=40.7166666666667 +lat_2=41.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=40.3333333333333 +lon_0=-111.5 +lat_1=40.7166666666667 +lat_2=41.7833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32044",
     "name": "NAD27 / Utah South",
-    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-111.5 +lat_1=37.2166666666667 +lat_2=38.35 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.6666666666667 +lon_0=-111.5 +lat_1=37.2166666666667 +lat_2=38.35 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32046",
     "name": "NAD27 / Virginia North",
-    "proj4": "+proj=lcc +lat_0=37.6666666666667 +lon_0=-78.5 +lat_1=38.0333333333333 +lat_2=39.2 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=37.6666666666667 +lon_0=-78.5 +lat_1=38.0333333333333 +lat_2=39.2 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32047",
     "name": "NAD27 / Virginia South",
-    "proj4": "+proj=lcc +lat_0=36.3333333333333 +lon_0=-78.5 +lat_1=36.7666666666667 +lat_2=37.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=36.3333333333333 +lon_0=-78.5 +lat_1=36.7666666666667 +lat_2=37.9666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32048",
     "name": "NAD27 / Washington North",
-    "proj4": "+proj=lcc +lat_0=47 +lon_0=-120.833333333333 +lat_1=47.5 +lat_2=48.7333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=47 +lon_0=-120.833333333333 +lat_1=47.5 +lat_2=48.7333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32049",
     "name": "NAD27 / Washington South",
-    "proj4": "+proj=lcc +lat_0=45.3333333333333 +lon_0=-120.5 +lat_1=45.8333333333333 +lat_2=47.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=45.3333333333333 +lon_0=-120.5 +lat_1=45.8333333333333 +lat_2=47.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32050",
     "name": "NAD27 / West Virginia North",
-    "proj4": "+proj=lcc +lat_0=38.5 +lon_0=-79.5 +lat_1=39 +lat_2=40.25 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=38.5 +lon_0=-79.5 +lat_1=39 +lat_2=40.25 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32051",
     "name": "NAD27 / West Virginia South",
-    "proj4": "+proj=lcc +lat_0=37 +lon_0=-81 +lat_1=37.4833333333333 +lat_2=38.8833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=37 +lon_0=-81 +lat_1=37.4833333333333 +lat_2=38.8833333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32053",
     "name": "NAD27 / Wisconsin Central",
-    "proj4": "+proj=lcc +lat_0=43.8333333333333 +lon_0=-90 +lat_1=44.25 +lat_2=45.5 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=43.8333333333333 +lon_0=-90 +lat_1=44.25 +lat_2=45.5 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32052",
     "name": "NAD27 / Wisconsin North",
-    "proj4": "+proj=lcc +lat_0=45.1666666666667 +lon_0=-90 +lat_1=45.5666666666667 +lat_2=46.7666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=45.1666666666667 +lon_0=-90 +lat_1=45.5666666666667 +lat_2=46.7666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32054",
     "name": "NAD27 / Wisconsin South",
-    "proj4": "+proj=lcc +lat_0=42 +lon_0=-90 +lat_1=42.7333333333333 +lat_2=44.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=lcc +lat_0=42 +lon_0=-90 +lat_1=42.7333333333333 +lat_2=44.0666666666667 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32055",
     "name": "NAD27 / Wyoming East",
-    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-105.166666666667 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-105.166666666667 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32056",
     "name": "NAD27 / Wyoming East Central",
-    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-107.333333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-107.333333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32058",
     "name": "NAD27 / Wyoming West",
-    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-110.083333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-110.083333333333 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {
     "epsg": "32057",
     "name": "NAD27 / Wyoming West Central",
-    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-108.75 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +nadgrids=NTv2_0.gsb +units=us-ft +no_defs +type=crs",
+    "proj4": "+proj=tmerc +lat_0=40.6666666666667 +lon_0=-108.75 +k=0.999941177 +x_0=152400.30480061 +y_0=0 +ellps=clrk66 +towgs84=8,-160,-176,0,0,0,0 +units=us-ft +no_defs +type=crs",
     "units": "feet"
   },
   {


### PR DESCRIPTION
## Summary
- replace NAD27 state plane proj4 definitions to use a +towgs84 fallback instead of NTv2_0.gsb grids
- guard reprojectFeatureCollection and shapefile export against non-finite projected coordinates and surface clear errors
- add a NAD27 regression test and ts-node dev dependency so the test suite can import TypeScript modules

## Testing
- node --loader ts-node/esm --test tests

------
https://chatgpt.com/codex/tasks/task_e_68d15da051c48320a7d5b96fb8d39592