### PR TITLE
Allow Land Cover upload before WSS and clarify non-blocking workflow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -757,16 +757,14 @@ const App: React.FC = () => {
       'Overall Drainage Area',
       'Drainage Areas',
       'LOD',
+      'Land Cover',
       'Soil Layer from Web Soil Survey',
     ]);
     if (drainageAreasAssigned) {
       names.add(SUBAREA_LAYER_NAME);
     }
-    if (soilsLoaded) {
-      names.add('Land Cover');
-    }
     return Array.from(names);
-  }, [drainageAreasAssigned, soilsLoaded]);
+  }, [drainageAreasAssigned]);
 
   const scsLayerStatuses = useMemo<ScsLayerStatus[]>(() => {
     const statuses: ScsLayerStatus[] = [
@@ -1222,10 +1220,8 @@ const App: React.FC = () => {
         if (name === 'Land Cover') {
           if (!soilsLoaded) {
             const msg =
-              'Carga primero la capa de suelos (WSS) antes de agregar la capa de Land Cover para mantener la secuencia de trabajo.';
-            setError(msg);
-            addLog(msg, 'error');
-            return;
+              'Advertencia: agregaste Land Cover sin una capa WSS cargada. Puedes continuar, pero deberás cargar y completar WSS para habilitar Compute.';
+            addLog(msg, 'warn');
           }
         }
 

--- a/components/InstructionsPage.tsx
+++ b/components/InstructionsPage.tsx
@@ -8,7 +8,7 @@ const instructionsContent = {
     stepsTitle: 'Pasos para comenzar',
     steps: [
       'Carga un archivo Shapefile o GeoPackage desde el panel izquierdo. Cada capa se validará automáticamente y el registro mostrará cualquier advertencia.',
-      'Primero sube las Drainage Areas, asigna un Discharge Point (DP-##) a cada polígono y luego incorpora las Drainage Subareas vinculándolas a esos mismos DP. Al completar esas asociaciones se habilitará la carga de la capa de suelos (WSS); después de cargarla podrás añadir la capa de Land Cover con la detección automática habitual.',
+      'Se recomienda subir primero las Drainage Areas, asignar un Discharge Point (DP-##) a cada polígono y luego incorporar las Drainage Subareas vinculándolas a esos mismos DP. También puedes cargar Land Cover antes de WSS si lo necesitas; solo considera que Compute seguirá deshabilitado hasta completar todos los insumos requeridos.',
       'Revisa el panel de capas para activar o desactivar la visibilidad, cambiar estilos y seleccionar qué capa editar.',
       'Usa el mapa para revisar geometrías. Puedes editar atributos clave como el Discharge Point # (DP-##), la cobertura del suelo y verificar o completar manualmente el HSG (A/B/C/D) en la capa WSS desde los controles contextuales.',
       'Cuando los datos estén listos, utiliza el botón Exportar para generar archivos HydroCAD, SWMM o nuevos Shapefiles, y confirma la proyección correspondiente.',
@@ -42,7 +42,7 @@ const instructionsContent = {
     stepsTitle: 'Getting started',
     steps: [
       'Upload a Shapefile or GeoPackage from the left panel. Each layer is validated automatically and the activity log will highlight any warnings.',
-      'Load the Drainage Areas first, assign a Discharge Point (DP-##) to every polygon, then import the Drainage Subareas and link them to those discharge points. Once those prerequisites are satisfied the WSS soil layer unlocks, and after it is loaded you can add the Land Cover layer with the usual auto-detection.',
+      'It is recommended to load Drainage Areas first, assign a Discharge Point (DP-##) to every polygon, then import Drainage Subareas and link them to those discharge points. You may also load Land Cover before WSS when needed; just note Compute remains disabled until all required inputs are complete.',
       'Review the layer panel to toggle visibility, adjust styles, and choose which layer is currently editable.',
       'Use the map to inspect geometries. Contextual controls let you edit key attributes like the Discharge Point # (DP-##), Land Cover, and review or manually complete the HSG value (A/B/C/D) on the WSS features.',
       'When the dataset is ready, open the Export dialog to generate HydroCAD, SWMM, or Shapefile outputs and confirm the desired projection.',


### PR DESCRIPTION
### Motivation
- Make the upload flow more flexible by allowing users to add a `Land Cover` layer before WSS instead of hard-blocking that action. 
- Preserve the integrity of the compute gating so `Compute` remains disabled until all required inputs are ready, while surfacing a non-blocking warning to the user.

### Description
- In `App.tsx` replaced the blocking error/`return` when adding `Land Cover` without WSS with a warning log via `addLog(..., 'warn')` so the layer can be added without stopping the flow. (File: `App.tsx`)
- Updated `allowedLayerNames` (in `App.tsx`) to always include `'Land Cover'` in the upload selector and removed the `soilsLoaded` dependency from the hook so the selector does not hide Land Cover. (File: `App.tsx`)
- Left the `scsLayerStatuses` and related ready checks unchanged so `scsReady`/`computeEnabled` logic continues to require all inputs before enabling `Compute`. (File: `App.tsx`)
- Clarified help text in both Spanish and English to state that the recommended load order is not mandatory and that `Compute` stays disabled until all inputs are complete. (File: `components/InstructionsPage.tsx`)

### Testing
- Ran `npm run build` and the production build completed successfully. (success)
- Started the dev server with `npm run dev` and captured a UI screenshot using a Playwright script to verify the updated instructions render; the snapshot generation succeeded. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f497cf3c8320a58b2d1b96f42583)